### PR TITLE
Fixed novnc flag

### DIFF
--- a/start_gui_tools/command.py
+++ b/start_gui_tools/command.py
@@ -42,8 +42,16 @@ Keyboard control:
         parser.add_argument(
             "--novnc",
             action="store_true",
+            dest='novnc',
             default=True,
-            help="should we run the novnc server",
+            help="Run the novnc server",
+        )
+
+        parser.add_argument(
+            "--no-novnc",
+            action="store_false",
+            dest='novnc',
+            help="Do not run the novnc server",
         )
             
         parsed_args = parser.parse_args(args)
@@ -134,12 +142,16 @@ Keyboard control:
             dtslogger.info(
                 "Running novnc. To use navigate your browser http://localhost:6901/vnc.html. Password is quackquack."
                 )
-            
+        else:
+            dtslogger.info(
+                "Not running novnc."
+            )
 
         
         attach_cmd = "docker attach %s" % container_name
         start_command_in_subprocess(attach_cmd)
 
-        dtslogger.info("Shutting down novnc...")
-        novnc_container.stop()
+        if parsed_args.novnc:
+            dtslogger.info("Shutting down novnc...")
+            novnc_container.stop()
         dtslogger.info("Done. Have a nice day")


### PR DESCRIPTION
With the current version of `start_gui_tools`, there is a command line flag for `novnc`. However, there is no way to disable this flag on the command line. If you try adding the flag `--novnc=False`, or `--novnc=0`, or any other variation, you get the error `error: argument --novnc: ignored explicit argument 'False'`. This is because argparse treats boolean arguments as switches: They are either present or not.

This was changed to the following:
 - The default behavior remains the same (No flag = `novnc` is enabled)
 - Adding the flag `--novnc` results in the same default behavior (`novnc` is enabled)
 - Adding the flag `--no-novnc` disables `novnc`. This is similar to how feature flags commonly work in command line programs (For example, GNU)

This fix is necessary because only one instance of `novnc` can run on a computer at a given time. In my testing, I am sometimes controlling two bots from my computer, with two image streams open from within two different instances of `gui_tools`. So, I need to disable `novnc` on at least one instance of `gui_tools`.