### PR TITLE
Update command.py

### DIFF
--- a/duckiebot/calibrate_extrinsics/command.py
+++ b/duckiebot/calibrate_extrinsics/command.py
@@ -33,7 +33,7 @@ Calibrate:
         parser.add_argument(
             "--base_image",
             dest="image",
-            default="duckietown/dt-core:daffy",
+            default="duckietown/dt-core:daffy-arm32v7",
         )
         parser.add_argument(
             "--no_verification",


### PR DESCRIPTION
Make default base image to daffy-arm32v7 instead of daffy. It seems the daffy image does not get built by jenkins