### PR TITLE
Update docker_utils.py

### DIFF
--- a/utils/docker_utils.py
+++ b/utils/docker_utils.py
@@ -73,7 +73,7 @@ def continuously_monitor(client, container_name):
                 follow=True,
                 since=last_log_timestamp,
             ):
-                if six.PY2:
+                if six.PY2 or (type(c) is str):
                     sys.stdout.write(c)
                 else:
                     sys.stdout.write(c.decode("utf-8"))


### PR DESCRIPTION
Fix `AttributeError: 'str' object has no attribute 'decode'`
If `c` is a string, we do not need to decode (and it will throw an error if we try to).
Error was thrown by running `dts duckiebot evaluate --native`