### PR TITLE
devel/docs/build: patched `intersphinx_mapping_default`

### DIFF
--- a/devel/docs/build/assets/docs/source/conf.py
+++ b/devel/docs/build/assets/docs/source/conf.py
@@ -11,7 +11,7 @@ import os.path
 import sys
 import tempfile
 import yaml
-from shutil import copyfile, rmtree
+from shutil import copyfile
 
 ######################################################################################################################
 #
@@ -172,12 +172,17 @@ napoleon_custom_section = [(sec_name, 'Parameters') for sec_name in config.get('
 
 
 # Intersphinx config
-intersphinx_mapping_default = {'python': ('https://docs.python.org/2.7',
-                                          (None, 'objects.inv'))}
+intersphinx_mapping_default = {
+    'python': {
+        'url': 'https://docs.python.org/2.7',
+        'inventories': ['objects.inv']
+    }
+}
+
 intersphinx_mapping = config.get('intersphinx_mapping', intersphinx_mapping_default)
 parsed = dict()
 for package, v in intersphinx_mapping.iteritems():
-    parsed[package] = (v['url'], tuple([None]+v['inventories']))
+    parsed[package] = (v['url'], tuple([None] + v['inventories']))
 intersphinx_mapping = parsed
 
 print(' - Intersphinx map: %s' % str(intersphinx_mapping))


### PR DESCRIPTION
I got this error,

```
INFO:dts:Building the documentation...
The environment variable VEHICLE_NAME is not set. Using 'b9bb44f15bc1'.
WARNING: robot_type file does not exist. Using 'duckiebot' as default type.
WARNING: robot_configuration file does not exist.
Running Sphinx v1.8.5
Configuring Sphinx:
Module name: dt_device_proxy
 - Searching for code documentation...
 - Reading config.yaml...
 - Validating docs version...
 - Reading mock_imports...
 - Setting up Sphinx...

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/usr/local/lib/python2.7/dist-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/usr/lib/python2.7/dist-packages/six.py", line 699, in exec_
    exec("""exec _code_ in _globs_, _locs_""")
  File "<string>", line 1, in <module>
  File "/docs/source/conf.py", line 180, in <module>
    parsed[package] = (v['url'], tuple([None]+v['inventories']))
TypeError: tuple indices must be integers, not str

cat: '/tmp/sphinx-err-*.log': No such file or directory
```

and I patched this way. 
Please, verify that I'm not messing with anything else!