### PR TITLE
Cleaned up Intrinsics Calibration

### DIFF
--- a/duckiebot/calibrate_intrinsics/command.py
+++ b/duckiebot/calibrate_intrinsics/command.py
@@ -29,7 +29,9 @@ Calibrate:
 
         parser = argparse.ArgumentParser(prog=prog, usage=usage)
         parser.add_argument(
-            "hostname", default=None, help="Name of the Duckiebot to calibrate"
+            "hostname",
+            default=None,
+            help="Name of the Duckiebot to calibrate"
         )
         parser.add_argument(
             "--base_image",
@@ -40,12 +42,11 @@ Calibrate:
             "--debug",
             action="store_true",
             default=False,
-            help="will enter you into the running container",
+            help="Will enter you into the running container",
         )
 
-        parsed_args = parser.parse_args(args)
-        hostname = parsed_args.hostname
-        duckiebot_ip = get_duckiebot_ip(hostname)
+        parsed = parser.parse_args(args)
+        duckiebot_ip = get_duckiebot_ip(parsed.hostname)
         duckiebot_client = get_remote_client(duckiebot_ip)
 
         # is the interface running?
@@ -57,67 +58,57 @@ Calibrate:
                     interface_container_found = True
             if not interface_container_found:
                 dtslogger.error(
-                    "The  duckiebot-interface is not running on the duckiebot"
+                    "The  duckiebot-interface is not running on the Duckiebot"
                 )
                 exit()
         except Exception as e:
             dtslogger.warn(
-                "Not sure if the duckiebot-interface is running because we got and exception when trying: %s"
-                % e
+                "We could not verify that the duckiebot-interface module is running. "
+                "The exception reads: %s" % e
             )
 
-        # is the raw imagery being published?
-        try:
-            duckiebot_containers = duckiebot_client.containers.list()
-            raw_imagery_found = False
-            for c in duckiebot_containers:
-                if "demo_intrinsic_calibration" in c.name:
-                    raw_imagery_found = True
-            if not raw_imagery_found:
-                dtslogger.warn(
-                    "The demo_intrinsic_calibration is not running on the duckiebot running `dts duckiebot demo "
-                    "--demo_name intrinsic_calibration --package_name image_processing --duckiebot_name %s`" % hostname
-                )
-                subprocess.call(["dts", "duckiebot", "demo", "--demo_name", "intrinsic_calibration",
-                                 "--package_name", "image_processing", "--duckiebot_name", "%s" % hostname])
-
-        except Exception as e:
-            dtslogger.warn("%s" % e)
-
-        image = parsed_args.image
-
         client = check_docker_environment()
-        container_name = "intrinsic_calibration_%s" % hostname
+        container_name = "dts-calibrate-intrinsics-%s" % parsed.hostname
         remove_if_running(client, container_name)
         env = {
-            "HOSTNAME": hostname,
-            "ROS_MASTER": hostname,
-            "DUCKIEBOT_NAME": hostname,
-            "ROS_MASTER_URI": "http://%s:11311" % duckiebot_ip,
+            "VEHICLE_NAME": parsed.hostname,
             "QT_X11_NO_MITSHM": 1,
         }
 
-        volumes = {}
         subprocess.call(["xhost", "+"])
 
-        p = platform.system().lower()
-        if "darwin" in p:
-            env["DISPLAY"] = "%s:0" % socket.gethostbyname(socket.gethostname())
-            volumes = {"/tmp/.X11-unix": {"bind": "/tmp/.X11-unix", "mode": "rw"}}
+        if "darwin" in platform.system().lower():
+            env.update({
+                "DISPLAY": "%s:0" % socket.gethostbyname(socket.gethostname()),
+                "ROS_MASTER": parsed.hostname,
+                "ROS_MASTER_URI": "http://%s:11311" % duckiebot_ip
+            })
+            volumes = {
+                "/tmp/.X11-unix": {
+                    "bind": "/tmp/.X11-unix",
+                    "mode": "rw"
+                }
+            }
         else:
             env["DISPLAY"] = os.environ["DISPLAY"]
+            volumes = {
+                "/var/run/avahi-daemon/socket": {
+                    "bind": "/var/run/avahi-daemon/socket",
+                    "mode": "rw"
+                }
+            }
 
         dtslogger.info(
             "Running %s on localhost with environment vars: %s" % (container_name, env)
         )
 
         dtslogger.info(
-            "When the window opens you will need to move the checkerboard around in front of the Duckiebot camera"
+            "When the window opens you will need to move the checkerboard around "
+            "in front of the Duckiebot camera.\nPress [Q] to close the window."
         )
-        cmd = "roslaunch intrinsic_calibration intrinsic_calibration.launch veh:=%s" % hostname
 
         params = {
-            "image": image,
+            "image": parsed.image,
             "name": container_name,
             "network_mode": "host",
             "environment": env,
@@ -125,14 +116,16 @@ Calibrate:
             "stdin_open": True,
             "tty": True,
             "detach": True,
-            "command": cmd,
+            "remove": True,
+            "auto_remove": True,
+            "command": 'dt-launcher-intrinsic-calibration',
             "volumes": volumes,
         }
 
-        pull_if_not_exist(client, image)
+        pull_if_not_exist(client, parsed.image)
 
-        container = client.containers.run(**params)
+        client.containers.run(**params)
 
-        if parsed_args.debug:
-            attach_cmd = "docker attach %s" % (container_name)
+        if parsed.debug:
+            attach_cmd = "docker attach %s" % container_name
             start_command_in_subprocess(attach_cmd)


### PR DESCRIPTION
This PR goes together with https://github.com/duckietown/dt-gui-tools/pull/7.

This change became possible after we based the `dt-gui-tools` image off of `dt-core`.

Improvements:
- We don't need to run a separate container just for the decoder node on the robot, we run the decoder node inside the dt-gui-tools container;
- Since the decoder now runs inside of dt-gui-tools, thus on the laptop instead of the Duckiebot, only compressed images will be transported from the Duckiebot to the laptop, then decoded to raw locally. This reduces latency and improves overall performances;
- Since decoder and calibrator are now launched by the same launch file, making the calibrator window `required` makes sure that when the window is closed, the decoder is automatically stopped.
- We can now run the calibration from a launcher on the VNC desktop. This opens up the possibility of running the camera calibration from the Dashboard (see image below);

![Screenshot from 2020-08-26 16-38-53](https://user-images.githubusercontent.com/22665009/91363253-d666ff00-e7c1-11ea-87bf-e52c4dfcbf61.jpg)
