### PR TITLE
devel docs : moved Sphinx to Python3 and integration with the book

### DIFF
--- a/devel/docs/build/Dockerfile
+++ b/devel/docs/build/Dockerfile
@@ -26,9 +26,9 @@ RUN cd "/" \
 
 RUN mkdir /docs/in
 RUN mkdir /docs/out
-RUN mkdir -p /sphinx_docs/out
+RUN mkdir -p /out
 
-COPY assets/output-html.manifest.yaml /sphinx_docs/out
+COPY assets/output-html.manifest.yaml /out
 
 RUN chmod -R 777 /docs
 
@@ -36,6 +36,6 @@ CMD cp -r /docs/in/* /docs/source/ \
     && cd /docs \
     && sphinx-build -b html source build/html \
     && cp -r /docs/build/html/* /docs/out \
-    && cp -r /docs/build/html/* /sphinx_docs/out \
-    && tar --create --verbose --file=/docs/out/package.tgz  /sphinx_docs/out/* \
+    && cp -r /docs/build/html/* /out \
+    && tar --create --gzip --verbose --file=/docs/out/package.tgz  /out/* \
     || cat /tmp/sphinx-err-*.log

--- a/devel/docs/build/Dockerfile
+++ b/devel/docs/build/Dockerfile
@@ -26,6 +26,9 @@ RUN cd "/" \
 
 RUN mkdir /docs/in
 RUN mkdir /docs/out
+RUN mkdir -p /sphinx_docs/out
+
+COPY assets/output-html.manifest.yaml /sphinx_docs/out
 
 RUN chmod -R 777 /docs
 
@@ -33,4 +36,6 @@ CMD cp -r /docs/in/* /docs/source/ \
     && cd /docs \
     && sphinx-build -b html source build/html \
     && cp -r /docs/build/html/* /docs/out \
+    && cp -r /docs/build/html/* /sphinx_docs/out \
+    && tar --create --verbose --file=/docs/out/package.tgz  /sphinx_docs/out/* \
     || cat /tmp/sphinx-err-*.log

--- a/devel/docs/build/Dockerfile
+++ b/devel/docs/build/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install \
-    sphinx==1.8.5 \
+RUN python3 -m pip install \
+    sphinx~=3.2.0 \
     sphinx-rtd-theme \
     sphinx-autobuild \
     pygments==2.5.2 \
@@ -22,7 +22,7 @@ COPY assets/docs /docs
 RUN cd "/" \
     && git clone https://github.com/AleksandarPetrov/napoleon \
     && cd /napoleon \
-    && python setup.py install -f
+    && python3 setup.py install -f
 
 RUN mkdir /docs/in
 RUN mkdir /docs/out

--- a/devel/docs/build/assets/docs/source/conf.py
+++ b/devel/docs/build/assets/docs/source/conf.py
@@ -181,7 +181,7 @@ intersphinx_mapping_default = {
 
 intersphinx_mapping = config.get('intersphinx_mapping', intersphinx_mapping_default)
 parsed = dict()
-for package, v in intersphinx_mapping.iteritems():
+for package, v in intersphinx_mapping.items():
     parsed[package] = (v['url'], tuple([None] + v['inventories']))
 intersphinx_mapping = parsed
 

--- a/devel/docs/build/assets/output-html.manifest.yaml
+++ b/devel/docs/build/assets/output-html.manifest.yaml
@@ -1,0 +1,4 @@
+- display: HTML Online version
+  filename: index.html
+  tags:
+  - document


### PR DESCRIPTION
Sphinx now uses Python3 so that it works with the new Python3 repositories.

Also the packaging of the output is updated to meet the requirements for integration with docs.duckietown.org.