### PR TITLE
Fix port biding already in use

### DIFF
--- a/exercises/test/command.py
+++ b/exercises/test/command.py
@@ -486,7 +486,7 @@ def launch_agent(
 
     if parsed.local:
         ros_template_params["network"] = agent_network.name
-        ros_template_params["ports"] = ros_port
+        #ros_template_params["ports"] = ros_port
     else:
         ros_template_params["network_mode"] = "host"
 


### PR DESCRIPTION
Not sure why this was added but I received multiple complains for docker.errors.APIError: 500 Server Error: Internal Server Error ("driver failed programming external connectivity on endpoint agent (cd868f8643b1fd186ad47419f8593638512db684ce7517c598df8c84b33daeca): Bind for 0.0.0.0:11312 failed: port is already allocated")
 (was able to reproduce).

Disabled for now