### PR TITLE
Fix calibration import on robot

### DIFF
--- a/exercises/test/command.py
+++ b/exercises/test/command.py
@@ -635,3 +635,14 @@ def get_calibration_files(destination_dir, duckiebot_name):
         with open(destination_file, "wb") as fd:
             for chunk in res.iter_content(chunk_size=128):
                 fd.write(chunk)
+                
+        # Also save them to specific robot name for local evaluation
+        destination_file2 = os.path.join(dirname, f"{duckiebot_name}.yaml")
+        dtslogger.debug(
+            'Writing calibration file "{:s}:{:s}" to "{:s}"'.format(
+                duckiebot_name, calib_file, destination_file2
+            )
+        )
+        with open(destination_file2, "wb") as fd:
+            for chunk in res.iter_content(chunk_size=128):
+                fd.write(chunk)


### PR DESCRIPTION
We were saving the file as `agent.yaml` but the workflow on the robot with `--local` was still looking for calib files with the duckiebot name.

This fix just duplicates the file to have it both as `agent.yaml` and `robot.yaml` to make sure nothing breaks