### PR TITLE
More verbose error when no duckiebot is specified

### DIFF
--- a/duckiebot/evaluate/command.py
+++ b/duckiebot/evaluate/command.py
@@ -100,6 +100,9 @@ class DTCommand(DTCommandAbs):
         dir_fake_home = os.path.join(tmpdir, "fake-%s-home" % USERNAME)
         if not os.path.exists(dir_fake_home):
             os.makedirs(dir_fake_home)
+            
+       if not parsed.duckiebot_name:
+            dtslogger.warning("No duckiebot Specified ! This will likely cause an error")
 
         if not parsed.raspberrypi and not parsed.jetsonnano:
             # if we are running remotely then we need to copy over the calibration


### PR DESCRIPTION
Note: I think the duckeibot name should be positional and required, but it is too late to modify that.