### PR TITLE
add check_firmware, wait for device-health to be healthy, add logs

### DIFF
--- a/duckiebot/battery/check_firmware/__init__.py
+++ b/duckiebot/battery/check_firmware/__init__.py
@@ -1,0 +1,36 @@
+# This is a default __init__ file for the Duckietown Shell commands
+#
+# Maintainer: Andrea F. Daniele
+
+from os.path import (
+    exists as _exists,
+    dirname as _dirname,
+    basename as _basename,
+    isdir as _isdir,
+    isfile as _isfile,
+    join as _join,
+)
+import glob as _glob
+
+# constants
+_this_dir = _dirname(__file__)
+_command_file = "command.py"
+
+# import current command
+if _exists(_join(_this_dir, _command_file)):
+    from .command import *
+
+# find all modules
+_modules = [m for m in _glob.glob(_join(_this_dir, "*")) if _isdir(m)]
+# this is important to avoid name clashing with commands at lower levels
+_modules.sort(key=lambda p: int(_isfile(_join(p, _command_file))))
+
+# load submodules
+for _mod in _modules:
+    try:
+        exec("from .%s import *" % _basename(_mod))
+    except ImportError as e:
+        if _exists(_join(_mod, _command_file)):
+            raise EnvironmentError(e)
+    except EnvironmentError as e:
+        raise e

--- a/duckiebot/battery/check_firmware/command.py
+++ b/duckiebot/battery/check_firmware/command.py
@@ -1,0 +1,25 @@
+import argparse
+
+import yaml
+import requests
+from dt_shell import DTCommandAbs, dtslogger, DTShell
+
+from utils.misc_utils import sanitize_hostname
+
+
+class DTCommand(DTCommandAbs):
+
+    help = "Shows info about the battery"
+
+    @staticmethod
+    def command(shell: DTShell, args):
+        prog = "dts duckiebot battery check_firmware"
+        parser = argparse.ArgumentParser(prog=prog)
+        parser.add_argument("duckiebot", default=None, help="Name of the Duckiebot")
+        parsed = parser.parse_args(args)
+        # fetch data from the health API
+        hostname = sanitize_hostname(parsed.duckiebot)
+        url = f"http://{hostname}/health/battery/info"
+        dtslogger.info(f"Fetching data from robot '{parsed.duckiebot}'...")
+        data = requests.get(url).json()
+        print(yaml.dump(data))

--- a/duckiebot/battery/upgrade/command.py
+++ b/duckiebot/battery/upgrade/command.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 from enum import IntEnum
 from threading import Thread
+from time import sleep
 
 import docker
 import requests
@@ -45,9 +46,10 @@ class DTCommand(DTCommandAbs):
         parsed = parser.parse_args(args)
         # want the use NOT TO interrupt this command
         dtslogger.warning(
-            "DO NOT unplug the battery, turn off your robot, or interrupt this "
-            "command. It might cause irreversible damage to the battery."
+            "\n\nDO NOT unplug the battery, turn off your robot, or interrupt "
+            "this command. It might cause irreversible damage to the battery.\n"
         )
+        sleep(3)
         # check if the health-api container is running
         dtslogger.info("Releasing battery...")
         hostname = sanitize_hostname(parsed.duckiebot)
@@ -76,6 +78,53 @@ class DTCommand(DTCommandAbs):
                 dtslogger.debug(f"Container '{HEALTH_CONTAINER_NAME}' not running.")
         else:
             dtslogger.debug(f"Container '{HEALTH_CONTAINER_NAME}' not found.")
+
+        def start_container_and_try_blocking_until_healthy(
+            container: docker.models.containers.Container,
+            msg_before: str = "Starting container...",
+            msg_after: str = "Container started.",
+            timeout_secs: int = 120,
+        ):
+            """
+            Start a container.
+            Try to wait until it's healthy. (If health status is enabled.)
+            """
+
+            dtslogger.info(msg_before)
+            sleep(10)  # verified multiple times, this wait time is needed
+            container.start()
+
+            def try_getting_health_status():
+                try:
+                    container.reload()
+                    return container.attrs.get('State').get('Health').get('Status')
+                except:
+                    return None
+
+            health_enabled = try_getting_health_status()
+            if health_enabled is not None:
+                dtslogger.info(
+                    f'Waiting for container "{container.name}" to become '
+                    "healthy. It may take up to 2 minutes."
+                )
+                healthy = False
+                secs = 0
+                while not healthy and secs < timeout_secs:
+                    dtslogger.debug(
+                        f'Container "{container.name}" not yet healthy. '
+                        "Checking every second..."
+                    )
+                    try:
+                        healthy = "healthy" == try_getting_health_status()
+                        sleep(1)
+                        secs += 1
+                    except KeyboardInterrupt:
+                        # force
+                        dtslogger.debug("User gave up waiting for container to become healty.")
+                        break
+
+            dtslogger.info(msg_after)
+
         # the battery should be free now
         dtslogger.info("Battery released!")
         # compile upgrade image name
@@ -107,6 +156,7 @@ class DTCommand(DTCommandAbs):
 
         # step 1. read the battery current version (unless forced)
         if not parsed.force:
+            dtslogger.info(f'Checking for available battery firmware updates...')
             # we run the helper in "check" mode and expect one of:
             #   - FIRMWARE_UP_TO_DATE           user will be notified
             #   - FIRMWARE_NEEDS_UPDATE         all well, user will be asked to confirm
@@ -153,9 +203,11 @@ class DTCommand(DTCommandAbs):
                     )
                     # re-activate device-health
                     if device_health:
-                        dtslogger.info("Re-engaging battery...")
-                        device_health.start()
-                        dtslogger.info("Battery returned to work!")
+                        start_container_and_try_blocking_until_healthy(
+                            container=device_health, 
+                            msg_before="Re-engaging battery...",
+                            msg_after="Battery returned to work!",
+                        )
                     exit(0)
                 #
                 elif status == ExitCode.FIRMWARE_NEEDS_UPDATE:
@@ -181,7 +233,19 @@ class DTCommand(DTCommandAbs):
         while True:
             answer = input(f"Press ENTER {txt}, 'q' to quit... ")
             if answer.strip() == "q":
+                # reset battery, start device_health container
+                dtslogger.warning('Set battery to "Normal Mode" by pressing the button ONCE on the battery.')
+                sleep(1)
+                input("Press ENTER when done...")
+                # re-activate device-health
+                if device_health:
+                    start_container_and_try_blocking_until_healthy(
+                        container=device_health, 
+                        msg_before="Re-engaging battery...",
+                        msg_after="Battery returned to work!",
+                    )
                 exit(0)
+            dtslogger.info('Checking if the battery has "Boot Mode" activated, please wait...')
             try:
                 client.containers.run(
                     image=image,
@@ -274,9 +338,11 @@ class DTCommand(DTCommandAbs):
 
         # re-activate device-health
         if device_health:
-            dtslogger.info("Re-engaging battery...")
-            device_health.start()
-            dtslogger.info("Battery returned to work happier than ever!")
+            start_container_and_try_blocking_until_healthy(
+                container=device_health, 
+                msg_before="Re-engaging battery...",
+                msg_after="Battery returned to work happier than ever!",
+            )
 
     @staticmethod
     def _consume_output(logs):


### PR DESCRIPTION
### For `check_firmware` command, verified:

```
duckietown@duckietown24:~$ dts duckiebot battery check_firmware autobot01                                                                                                                                            
                                                                                                                                                                                                                     
dts :  Problems with a command?                                                                                                                                                                                      
    :                                                                                                                                                                                                                
    :      Report here: https://github.com/duckietown/duckietown-shell-commands/issues                                                                                                                               
    :                                                                                                                                                                                                                
    :      Troubleshooting:                                                                                                                                                                                          
    :                                                                                                                                                                                                                
    :      - If some commands update fail, delete ~/.dt-shell/commands                                                                                                                                               
    :                                                                                                                                                                                                                
    :      - To reset the shell to "factory settings", delete ~/.dt-shell                                                                                                                                            
    :                                                                                                                                                                                                                
    :        (Note: you will have to re-configure.)                                                                                                                                                                  
INFO:dts:Commands version: daffy                                                                                                                                                                                     
INFO:dts:Using path '/home/duckietown/Repositories/jasonhu5/duckietown-shell-commands' as prescribed by env variable DTSHELL_COMMANDS.                                                                               
INFO:dts:Fetching data from robot 'autobot01'...                                                                                                                                                                     
boot:                                                                                                                                                                                                                
  date: 11/19/19                                                                                                                                                                                                     
  pcb_version: '16'                                                                                                                                                                                                  
  version: '1'                                                                                                                                                                                                       
serial_number: 5A09F56F                                                                                                                                                                                              
version: 2.0.1    
```

### For `upgrade` command
Code is added to wait until the *device-health* container becomes healthy. So after the command finishes, shutdown/battery/health related actions would work directly.