### PR TITLE
Enable Docker images to run shell scripts for exercise test commands

### DIFF
--- a/exercises/test/command.py
+++ b/exercises/test/command.py
@@ -956,6 +956,7 @@ def launch_agent(
 
     pull_if_not_exist(agent_client, agent_params["image"])
     agent_container = agent_client.containers.run(**agent_params)
+    agent_container.exec_run(f"chmod +x /code/launchers/{config['agent_run_cmd']}")
 
     attach_cmd = "docker %s attach %s" % (
         "" if parsed.local else f"-H {duckiebot_name}.local",


### PR DESCRIPTION
During running of Docker images on a physical Duckiebot the Docker image will run a shell command which runs the main script for the exercises. However during the entrypoint script Docker runs, it fails to run the script because the script wasn't given proper permission. This pull request adds a simple command to address this issue with no conflicts with the current code.