### PR TITLE
Create command line argument to specify custom base agent Docker Images

### DIFF
--- a/exercises/test/command.py
+++ b/exercises/test/command.py
@@ -956,6 +956,7 @@ def launch_agent(
 
     pull_if_not_exist(agent_client, agent_params["image"])
     agent_container = agent_client.containers.run(**agent_params)
+    agent_container.exec_run(f"chmod +x /code/launchers/{config['agent_run_cmd']}")
 
     attach_cmd = "docker %s attach %s" % (
         "" if parsed.local else f"-H {duckiebot_name}.local",

--- a/exercises/test/command.py
+++ b/exercises/test/command.py
@@ -190,6 +190,13 @@ class DTCommand(DTCommandAbs):
         )
 
         parser.add_argument("launcher", nargs="?", default=None, help="(Optional) Launcher to execute")
+        
+        parser.add_argument(
+            "--docker_image",
+            dest="docker_image",
+            default="",
+            help="Name of the Docker Image on which to run the exercise",
+        )
 
         parsed = parser.parse_args(args)
 
@@ -328,7 +335,7 @@ class DTCommand(DTCommandAbs):
             expman_spec = ImageRunSpec(add_registry(EXPERIMENT_MANAGER_IMAGE), expman_env, ports=[])
         # let's update the images based on arch
         ros_image = add_registry(f"{ROSCORE_IMAGE}-{arch}")
-        agent_base_image = add_registry(f"{agent_base_image0}-{arch}")
+        agent_base_image = add_registry(f"{agent_base_image0}-{arch}") if parsed.docker_image == "" else parsed.docker_image
         bridge_image = add_registry(f"{BRIDGE_IMAGE}-{arch}")
 
         # let's clean up any mess from last time


### PR DESCRIPTION
This is the first step to being able to run custom images on a physical Duckiebot for more complex exercises. Assuming the specified image has already been built on the Duckiebot, and assuming the built image has the same base architecture as the Duckiebot, this will run the same as the premade Docker images available on the Docker hub.

This code can be further expanded to give options for building images through the duckietown shell, perhaps through the build command. Example code below is the needed code for the Dockerfile in order to properly build an image on a physical Duckiebot.

```
ARG ARCH=arm64v8
ARG MAJOR=daffy
ARG BASE_TAG=${MAJOR}-${ARCH}

FROM docker.io/duckietown/challenge-aido_lf-baseline-duckietown:${BASE_TAG}

ARG PIP_INDEX_URL="https://pypi.org/simple"
ENV PIP_INDEX_URL=${PIP_INDEX_URL}
WORKDIR /agent

COPY requirements.* ./
RUN cat requirements.* > .requirements.txt
RUN echo PIP_INDEX_URL=$PIP_INDEX_URL
RUN python3 -m pip install  -r .requirements.txt
```

For now users would have to ssh onto the Duckiebot, rsync over the Dockerfile and requirements.txt files and manually call `docker build`. Notice the `arm64v8` is the same architecture as the Dockiebot. This code will properly install new pip packages from a given requirements.txt which is required for complex exercises, for example the object detection exercises using Yolov5.

Note: This pull request also contains code from a previous pull request found [here](https://github.com/duckietown/duckietown-shell-commands/pull/326).