### PR TITLE
check free disk space before desktop update

### DIFF
--- a/desktop/update/command.py
+++ b/desktop/update/command.py
@@ -10,6 +10,11 @@ from utils.docker_utils import (
     pull_image,
 )
 from utils.duckietown_utils import get_distro_version
+from utils.disk_space_utils import (
+    check_enough_disk,
+    num_bytes_to_simple_friendly_str,
+)
+from utils.cli_utils import ask_confirmation
 
 OTHER_IMAGES_TO_UPDATE = [
     "{registry}/duckietown/dt-gui-tools:{distro}-{arch}",
@@ -22,6 +27,8 @@ OTHER_IMAGES_TO_UPDATE = [
     "{registry}/duckietown/aido-base-python3:{distro}-{arch}",
 ]
 
+DISK_SPACE_REQUIRED_SOFT = 10 * ((2 ** 10) ** 3)  # prompt
+DISK_SPACE_REQUIRED_HARD = 3 * ((2 ** 10) ** 3)  # abort
 
 class DTCommand(DTCommandAbs):
     @staticmethod
@@ -31,6 +38,39 @@ class DTCommand(DTCommandAbs):
 
         # parse arguments
         parsed = parser.parse_args(args)
+
+        # check curr disk space. If not enough, abort
+        dtslogger.info("Checking disk space now...")
+        res = check_enough_disk(DISK_SPACE_REQUIRED_SOFT)
+
+        if res is None:  # could not check disk space
+            msg = (
+                "Unable to determine whether disk space is sufficient. "
+                "Please open an issue on Github.\n"
+                "Please make sure you have enough disk space before continue."
+            )
+            # prompt whether to proceed
+            res = ask_confirmation(
+                message=msg,
+                question="Would you like to continue?",
+            )
+            if not res:
+                return
+        elif res is False: # below soft limit
+            res = check_enough_disk(DISK_SPACE_REQUIRED_HARD)
+            if not res:  # below hard limit, abort
+                tmp = num_bytes_to_simple_friendly_str(DISK_SPACE_REQUIRED_HARD)
+                dtslogger.error(f"Not enough disk space! Minimum {tmp} needed.")
+                return
+
+            # between soft and hard limit. prompt whether to proceed
+            tmp = num_bytes_to_simple_friendly_str(DISK_SPACE_REQUIRED_SOFT)
+            res = ask_confirmation(
+                message=f"Your free disk space is below the recommended {tmp}.",
+                question="Would you like to continue anyways?",
+            )
+            if not res:
+                return
 
         registry_to_use = get_registry_to_use()
 

--- a/utils/disk_space_utils.py
+++ b/utils/disk_space_utils.py
@@ -1,0 +1,79 @@
+import sys
+import shutil
+from typing import Union, Optional
+
+from dt_shell import dtslogger
+
+
+_DISK_ROOT_PATH = "/"
+# margin to spare, the less of the two is used
+
+# _DISK_SPACE_MARGIN_PERC = 1.0  # 1% of total disk
+# _DISK_SPACE_MARGIN_BYTES_ABS = (2 ** 20) * 500  # 500 MB
+
+# strict comparison
+_DISK_SPACE_MARGIN_PERC = 0.0
+_DISK_SPACE_MARGIN_BYTES_ABS = 0
+
+# KB, MB, GB
+_CONST_NUM_BYTES_IN_KB = 2 ** 10
+_CONST_NUM_BYTES_IN_MB = _CONST_NUM_BYTES_IN_KB ** 2
+_CONST_NUM_BYTES_IN_GB = _CONST_NUM_BYTES_IN_KB ** 3
+
+
+def check_enough_disk(value: Union[str, float]) -> Optional[bool]:
+    """Whether the local disk space is enough given the demanded value
+
+    Args:
+        value (Union[str, float]): number of Bytes required
+
+    Returns:
+        Optional[bool]: if not None, disk space satisfied or not. If None, error
+    """
+
+    # TODO: windows?
+    try:
+        stats = shutil.disk_usage(_DISK_ROOT_PATH)
+        margin_by_perc = _DISK_SPACE_MARGIN_PERC / 100.0 * stats.total
+        margin = min(margin_by_perc, _DISK_SPACE_MARGIN_BYTES_ABS)
+        dtslogger.debug(f"Disk stats: {stats}")
+        if float(value) + margin <= stats.free:
+            return True
+        else:
+            return False
+    except Exception as e:
+        dtslogger.warning((
+            "Unable to determine whether sufficient disk space is present. "
+            f"Error details: {e}"
+        ))
+
+
+def num_bytes_to_simple_friendly_str(num_bytes: int) -> str:
+    f_n = float(num_bytes)
+    res = f_n / _CONST_NUM_BYTES_IN_GB
+    if res > 1:
+        return f"{res:.2f}GB"
+
+    res = f_n / _CONST_NUM_BYTES_IN_MB
+    if res > 1:
+        return f"{res:.2f}MB"
+
+    res = f_n / _CONST_NUM_BYTES_IN_KB
+    if res > 1:
+        return f"{res:.2f}KB"
+
+    return f"{num_bytes}B"
+
+
+if __name__ == "__main__":
+    try:
+        assert len(sys.argv) >= 2, f"[Usage] python {sys.argv[0]} value"
+        test_val = sys.argv[1]
+
+        # usage example
+        res = check_enough_disk(test_val)
+        if res is not None:
+            print(f"Enough disk space for <{test_val} Bytes>? [{res}]")
+
+    except Exception as e:
+        print(f"Error testing. Details: {e}")


### PR DESCRIPTION
Check storage before pulling images in `dts desktop update`.

* Thresholds: Soft limit (10GB), hard limit (3GB)
* Behaviors:
  * `> soft`: ok
  * `hard - soft`: prompt
  * `< hard`: abort

Tests performed (by setting some particular threshold values, user has ~180GB free):
1. `hard (100) - soft (200)`, user aborts ![Screenshot from 2022-11-02 14-41-03](https://user-images.githubusercontent.com/10885835/199504792-e8323f28-5e30-4618-9dd8-e663554a0350.png)
2. `hard (100) - soft (200)`, user continues ![Screenshot from 2022-11-02 14-40-42](https://user-images.githubusercontent.com/10885835/199505037-55babd2e-e359-4fab-bba0-8336e7d3060b.png)
3. `< hard (200)`, program aborts ![Screenshot from 2022-11-02 14-24-42](https://user-images.githubusercontent.com/10885835/199505151-a0af8d51-280d-4bc7-bef4-48c5734403d5.png)