### PR TITLE
dts docs preview command and dts docs build --preview support

### DIFF
--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,2 +1,3 @@
 from .build import *
 from .clean import *
+from .preview import *

--- a/docs/build/command.py
+++ b/docs/build/command.py
@@ -3,6 +3,7 @@ import getpass
 import os
 import subprocess
 import sys
+import copy
 
 from dt_shell import DTCommandAbs, DTShell, dtslogger
 from dt_shell.env_checks import check_docker_environment
@@ -18,6 +19,9 @@ class DTCommand(DTCommandAbs):
         parser.add_argument(
             "--image", default="${%s}/duckietown/docs-build:daffy" % ENV_REGISTRY, help="Which image to use"
         )
+
+        parser.add_argument('--preview', default=False, action='store_true',
+                            help="Opens the compiled page when complete")
 
         parsed = parser.parse_args(args=args)
 
@@ -84,6 +88,9 @@ class DTCommand(DTCommandAbs):
 
         p.communicate()
         dtslogger.info("\n\nCompleted.")
+
+        if parsed.preview:
+            shell.include.docs.preview.command(shell, [])
 
 
 def system_cmd_result(pwd, cmd):

--- a/docs/build/command.py
+++ b/docs/build/command.py
@@ -3,7 +3,6 @@ import getpass
 import os
 import subprocess
 import sys
-import copy
 
 from dt_shell import DTCommandAbs, DTShell, dtslogger
 from dt_shell.env_checks import check_docker_environment

--- a/docs/preview/__init__.py
+++ b/docs/preview/__init__.py
@@ -1,0 +1,1 @@
+from .command import DTCommand

--- a/docs/preview/command.py
+++ b/docs/preview/command.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import webbrowser
+from glob import glob
+
+from dt_shell import DTCommandAbs, DTShell, dtslogger
+
+class DTCommand(DTCommandAbs):
+    help = "Opens compiled docs"
+
+    @staticmethod
+    def _parse_args(args):
+        # configure arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--all", action='store_true',
+                            help="Show build artifact log during preview.")
+        parsed, _ = parser.parse_known_args(args=args)
+        return parsed
+
+    @staticmethod
+    def command(shell: DTShell, args):
+        parsed = DTCommand._parse_args(args)
+        local_directories = glob("duckuments-dist/*/")
+        if len(local_directories) < 1:
+            dtslogger.warning("Cannot find a compiled book. Trying to trigger a document build first!")
+            shell.include.docs.build.command(shell, [])
+            local_directories = glob("duckuments-dist/*/")
+            if len(local_directories) < 1:
+                dtslogger.error("Tried building the duckuments but failed!")
+                exit(2)
+        for entry in local_directories:
+            if "junit" not in entry:
+                directory_name = entry.replace("duckuments-dist/", "")
+                directory_name = directory_name.replace("/", "")
+        dtslogger.info("Currently the book is: %s" % directory_name)
+        main = "file://" + os.getcwd() + "/duckuments-dist/" + directory_name + "/out/index.html"
+        webbrowser.open(main, new=1)
+        if parsed.all:
+            error_file = "file://" + os.getcwd() + "/duckuments-dist/errors.html"
+            warning_file = "file://" + os.getcwd() + "/duckuments-dist/warnings.html"
+            todo_file = "file://" + os.getcwd() + "/duckuments-dist/tasks.html"
+            webbrowser.open_new_tab(error_file)
+            webbrowser.open_new_tab(warning_file)
+            webbrowser.open_new_tab(todo_file)
+
+    @staticmethod
+    def complete(shell, word, line):
+        return []


### PR DESCRIPTION
This PR added the following behaviors:
1. `dts docs preview` command where it will check if a duckumentation is built or not, if not built first and then show the content in a web browser
2. `dts docs preview --all` command where it will show all build artifact, including how many errors and how many warnings in the same web browser after showing the main document content
3. `dts docs build --preview` command where it will show the duckumentation preview after it is being built.