### PR TITLE
data get token attribute error catch

### DIFF
--- a/data/get/command.py
+++ b/data/get/command.py
@@ -97,7 +97,13 @@ Where <space> can be one of {str(VALID_SPACES)}.
         # sanitize file path
         parsed.file = os.path.abspath(parsed.file)
         # get the token if it is set
-        token = parsed.token
+        token = None
+        try:
+            token = parsed.token
+        except AttributeError:
+            # if parsed is supplied when shell.include.data.get.command(...)
+            pass
+
         if token is None:
             # noinspection PyBroadException
             try:


### PR DESCRIPTION
When using `data/get` command with `shell.include.data.get.command(...)` syntax, existing calls do not pass `token` param in the `parsed` field, leading to an AttributeError. This PR creates a simple fix by catching and forgiving if the `parsed` arg doesn't have the attribute