### PR TITLE
Add config/docker command

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,36 @@
+# This is a default __init__ file for the Duckietown Shell commands
+#
+# Maintainer: Andrea F. Daniele
+
+import glob as _glob
+from os.path import (
+    basename as _basename,
+    dirname as _dirname,
+    exists as _exists,
+    isdir as _isdir,
+    isfile as _isfile,
+    join as _join,
+)
+
+# constants
+_this_dir = _dirname(__file__)
+_command_file = "command.py"
+
+# import current command
+if _exists(_join(_this_dir, _command_file)):
+    from .command import *
+
+# find all modules
+_modules = [m for m in _glob.glob(_join(_this_dir, "*")) if _isdir(m)]
+# this is important to avoid name clashing with commands at lower levels
+_modules.sort(key=lambda p: int(_isfile(_join(p, _command_file))))
+
+# load submodules
+for _mod in _modules:
+    try:
+        exec("from .%s import *" % _basename(_mod))
+    except ImportError as e:
+        if _exists(_join(_mod, _command_file)):
+            raise EnvironmentError(e)
+    except EnvironmentError as e:
+        raise e

--- a/config/docker/__init__.py
+++ b/config/docker/__init__.py
@@ -1,0 +1,36 @@
+# This is a default __init__ file for the Duckietown Shell commands
+#
+# Maintainer: Andrea F. Daniele
+
+import glob as _glob
+from os.path import (
+    basename as _basename,
+    dirname as _dirname,
+    exists as _exists,
+    isdir as _isdir,
+    isfile as _isfile,
+    join as _join,
+)
+
+# constants
+_this_dir = _dirname(__file__)
+_command_file = "command.py"
+
+# import current command
+if _exists(_join(_this_dir, _command_file)):
+    from .command import *
+
+# find all modules
+_modules = [m for m in _glob.glob(_join(_this_dir, "*")) if _isdir(m)]
+# this is important to avoid name clashing with commands at lower levels
+_modules.sort(key=lambda p: int(_isfile(_join(p, _command_file))))
+
+# load submodules
+for _mod in _modules:
+    try:
+        exec("from .%s import *" % _basename(_mod))
+    except ImportError as e:
+        if _exists(_join(_mod, _command_file)):
+            raise EnvironmentError(e)
+    except EnvironmentError as e:
+        raise e

--- a/config/docker/command.py
+++ b/config/docker/command.py
@@ -1,0 +1,61 @@
+import argparse
+import os
+from typing import List
+
+from dt_shell import DTCommandAbs, dtslogger, DTShell
+
+
+class DTCommand(DTCommandAbs):
+    help = "Configure docker registry credentials"
+
+    usage = f"""
+Usage:
+
+    dts config docker --docker-username <your-docker-username> --docker-password <your-docker-access-token> [--docker-registry <optional-specific-registry>]
+"""
+
+    @staticmethod
+    def command(shell, args, **kwargs):
+        parser = argparse.ArgumentParser(prog="dts config docker")
+        parser.add_argument(
+            "--docker-registry",
+            "--docker-server",
+            dest="server",
+            help="Docker server",
+            default="docker.io",
+        )
+        parser.add_argument(
+            "--docker-username",
+            dest="username",
+            help="Docker username",
+            required=True,
+        )
+        parser.add_argument(
+            "--docker-password",
+            dest="password",
+            help="Docker password or Docker token",
+            required=True,
+        )
+        parsed = parser.parse_args(args)
+
+        username = parsed.username
+        password = parsed.password
+
+        server = parsed.server
+
+        if server not in shell.shell_config.docker_credentials:
+            shell.shell_config.docker_credentials[server] = {}
+        
+        if username is None and password is None:
+            print(DTCommand.usage)
+            exit(4)
+
+        if username is not None:
+            shell.shell_config.docker_username = username
+            shell.shell_config.docker_credentials[server]["username"] = username
+        if password is not None:
+            shell.shell_config.docker_password = password
+            shell.shell_config.docker_credentials[server]["secret"] = password
+
+        shell.save_config()
+        dtslogger.info("Docker access credentials stored!")

--- a/data/get/command.py
+++ b/data/get/command.py
@@ -52,9 +52,16 @@ Where <space> can be one of {str(VALID_SPACES)}.
 
     @staticmethod
     def command(shell, args, **kwargs):
+        # Get pre-parsed or parse arguments
         parsed = kwargs.get("parsed", None)
-        if parsed is None:
-            parsed = DTCommand._parse_args(args)
+        if not parsed:
+            parsed = DTCommand._parse_args(args=args)
+        else:
+            # combine given args with default values
+            default_parsed = DTCommand._parse_args(args=[])
+            for k, v in parsed.__dict__.items():
+                setattr(default_parsed, k, v)
+            parsed = default_parsed
         # ---
         parsed.object = parsed.object[0]
         parsed.file = parsed.file[0]

--- a/data/get/command.py
+++ b/data/get/command.py
@@ -58,7 +58,7 @@ Where <space> can be one of {str(VALID_SPACES)}.
             parsed = DTCommand._parse_args(args=args)
         else:
             # combine given args with default values
-            default_parsed = DTCommand._parse_args(args=[])
+            default_parsed = DTCommand._parse_args(args=[parsed.object, parsed.file])
             for k, v in parsed.__dict__.items():
                 setattr(default_parsed, k, v)
             parsed = default_parsed

--- a/docs/publish/command.py
+++ b/docs/publish/command.py
@@ -87,6 +87,12 @@ class DTCommand(DTCommandAbs):
         BOOK_NAME = project.name
         BOOK_BRANCH_NAME = project.version_name
 
+        # custom distro
+        if parsed.distro:
+            dtslogger.info(f"Using custom distro '{parsed.distro}'")
+        else:
+            parsed.distro = get_distro_version(shell)
+
         # create docker client
         docker = dockertown.DockerClient(debug=debug)
 

--- a/duckiebot/demo/command.py
+++ b/duckiebot/demo/command.py
@@ -232,8 +232,6 @@ class DTCommand(DTCommandAbs):
         )
 
         if parsed.demo_name == "base" or parsed.debug:
-            attach_cmd = "docker -H %s attach %s" % (
-                duckiebot_hostname,
-                container_name,
-            )
+            opt_remote_host = "" if parsed.local else f"-H {duckiebot_hostname}"
+            attach_cmd = f"docker {opt_remote_host} attach {container_name}"
             start_command_in_subprocess(attach_cmd)


### PR DESCRIPTION
Docker credentials configurations are needed in scenarios not limited to AIDO challenges. Thus leaving the configuration in the AIDO book and with `dts challenges` command seem not sensible. This PR aims to rename `dts challenges config` to `dts config docker`, as well as leaving the possibility to keep all configurations under `dts` in `dts config`.