### PR TITLE
Fix versioning issue with Jetson Nano 2Gb

### DIFF
--- a/init_sd_card/command.py
+++ b/init_sd_card/command.py
@@ -87,7 +87,7 @@ def PLACEHOLDERS_VERSION(robot_configuration, experimental=False):
         },
         "jetson_nano_2gb": {
             # - stable
-            "1.2.1": "1.1",
+            "1.2.2": "1.1",
             # - experimental
             "-----": "1.1"
         },


### PR DESCRIPTION
A recent commit broke the Jetson Nano 2Gb board version. In the `DISK_IMAGE_VERSION` function the version was set to `1.2.2`, but when attempting to retrieve this version in the `PLACEHOLDERS_VERSION` function, such a version didn't exist in `board_to_placeholders_version`. Updated the version to be `1.2.2` in both functions.