### PR TITLE
Marge up staging - VNC + workbench fixes (#408)

### DIFF
--- a/code/workbench/command.py
+++ b/code/workbench/command.py
@@ -14,7 +14,9 @@ import subprocess
 import threading
 import time
 import traceback
+import yaml
 from dataclasses import dataclass
+from docker.models.networks import Network
 from enum import Enum
 from types import SimpleNamespace
 from typing import Callable, cast, Dict, List, Optional, Iterable
@@ -79,6 +81,7 @@ PORT_VNC = 8087
 PORT_MANAGER = 8090
 
 ROBOT_LOGS_DIR = "/data/logs"
+INFTY = 86400
 
 
 class Levels(Enum):
@@ -135,14 +138,48 @@ class SettingsFile:
     rsync_exclude: List[str] = dataclasses.field(default_factory=list)
 
     # editor configuration
-    editor: dict = dataclasses.field(default_factory=dict)
+    editor: Dict[str, object] = dataclasses.field(default_factory=dict)
 
-    def __str__(self):
+    def __str__(self) -> str:
         fields: Iterable[dataclasses.Field] = dataclasses.fields(SettingsFile)
         return "\n\t" + "\n\t".join(f"{field.name}: {getattr(self, field.name)}" for field in fields) + "\n"
 
 
-ALLOWED_LEVELS = [e.value for e in Levels]
+def SettingsFile_from_yaml(filename: str) -> SettingsFile:
+    data = load_yaml(filename)
+    if not isinstance(data, dict):
+        msg = f'Expected that the settings file {filename!r} would be a dictionary, obtained {type(data)}.'
+        raise Exception(msg)
+
+    data_dict = cast(Dict[str, object], data)
+    known: Dict[str, object] = {
+        'agent_base': None,
+        'ws_dir': None,
+        'log_dir': None,
+        'ros': True,
+        'step': None,
+        'rsync_exclude': [],
+        'editor': {},
+    }
+
+    params = {}
+    for k, default in known.items():
+        params[k] = data_dict.get(k, default)
+
+    extra = {}
+    for k, v in data_dict.items():
+        if k not in known:
+            extra[k] = v
+    if extra:
+        dtslogger.warn(f'Ignoring extra keys {list(extra)} in {filename!r}')
+
+    settings = SettingsFile(**params)
+
+    return settings
+
+
+# noinspection PyTypeChecker
+ALLOWED_LEVELS: List[str] = [e.value for e in Levels]
 LOG_LEVELS: Dict[ContainerNames, Levels] = {
     ContainerNames.NAME_AGENT: Levels.LEVEL_DEBUG,
     ContainerNames.NAME_MANAGER: Levels.LEVEL_NONE,
@@ -388,7 +425,7 @@ class DTCommand(DTCommandAbs):
             msg = "Recipe must contain a 'settings.yaml' file"
             dtslogger.error(msg)
             exit(1)
-        settings: SettingsFile = SettingsFile(**load_yaml(settings_file))
+        settings: SettingsFile = SettingsFile_from_yaml(settings_file)
 
         # custom settings
         challenge: str = parsed.challenge or get_challenge_from_submission_file(recipe)
@@ -406,7 +443,7 @@ class DTCommand(DTCommandAbs):
         # TODO: what is this for?
         # environment directory is in the recipe
         environment_dir = os.path.join(recipe.path, "assets", "environment")
-        if not os.path.exists(environment_dir):
+        if parsed.simulation and not os.path.exists(environment_dir):
             msg = "Recipe must contain a 'assets/environment' directory"
             raise InvalidUserInput(msg)
 
@@ -427,11 +464,8 @@ class DTCommand(DTCommandAbs):
         local_arch: str = get_endpoint_architecture_from_client_OLD(local_client)
 
         # check user inputs
-        # - we run either in simulation or we need a duckiebot name
         duckiebot = parsed.duckiebot
-        if duckiebot is None and not parsed.simulation:
-            msg = "You must specify a '--duckiebot' or run in '--simulation' mode"
-            raise InvalidUserInput(msg)
+        has_agent: bool = parsed.simulation or parsed.duckiebot
 
         # - running in simulation forces a local run
         if not parsed.local and parsed.simulation:
@@ -439,15 +473,14 @@ class DTCommand(DTCommandAbs):
             parsed.local = True
 
         # - resolve duckiebot information if we are not using the simulator
-        # TODO: duckiebot_ip is not used
-        duckiebot_client = duckiebot_hostname = duckiebot_ip = None
-        if not parsed.simulation:
+        duckiebot_client = duckiebot_hostname = None
+        if parsed.duckiebot:
             duckiebot_ip = get_duckiebot_ip(duckiebot)
             duckiebot_client = get_remote_client(duckiebot_ip)
             duckiebot_hostname = sanitize_hostname(duckiebot)
 
         # agent is local
-        agent_is_local: bool = parsed.simulation or parsed.local
+        agent_is_local: bool = parsed.simulation or parsed.local or not has_agent
 
         # build agent
         dtslogger.info(f"Building Agent...")
@@ -466,9 +499,14 @@ class DTCommand(DTCommandAbs):
             dtslogger.error("Failed to build the agent image. Aborting.")
             exit(1)
 
+        # image names
+        bridge_image: Optional[str] = None
+        agent_image: Optional[str] = None
         # sync code with the robot if we are running on a physical robot
+        sim_spec: Optional[ImageRunSpec] = None
+        expman_spec: Optional[ImageRunSpec] = None
         agent_client = local_client
-        if not parsed.local:
+        if not parsed.local and has_agent:
             if parsed.sync:
                 # let's set some things up to run on the Duckiebot
                 check_program_dependency("rsync")
@@ -484,36 +522,36 @@ class DTCommand(DTCommandAbs):
             # the agent runs on the duckiebot client
             agent_client = duckiebot_client
 
-        # get agent's architecture and image name
-        arch: str = get_endpoint_architecture_from_client_OLD(agent_client)
-        agent_image = project.image(registry=parsed.registry, arch=arch, owner=username)
+        if has_agent:
+            # get agent's architecture and image name
+            agent_arch = get_endpoint_architecture_from_client_OLD(agent_client)
+            agent_image = project.image(registry=parsed.registry, arch=agent_arch, owner=username)
 
-        # docker container specifications for simulator and experiment manager
-        sim_spec: ImageRunSpec
-        expman_spec: ImageRunSpec
-        if use_challenge:
-            # make sure the token is set
-            token = shell.shell_config.token_dt1
-            if token is None:
-                raise UserError("Please set token using the command 'dts tok set'")
-            # get container specs from the challenges server
-            images = get_challenge_images(challenge=challenge, step=settings.step, token=token)
-            sim_spec = images["simulator"]
-            expman_spec = images["evaluator"]
-        else:
-            # load container specs from the environment configuration
-            sim_env = load_yaml(os.path.join(environment_dir, "sim_env.yaml"))
-            sim_spec = ImageRunSpec(
-                docker_image(SIMULATOR_IMAGE, parsed.registry), environment=sim_env, ports=[]
-            )
-            expman_env = load_yaml(os.path.join(environment_dir, "exp_manager_env.yaml"))
-            expman_spec = ImageRunSpec(
-                docker_image(EXPERIMENT_MANAGER_IMAGE, parsed.registry), environment=expman_env, ports=[]
-            )
+            # docker container specifications for simulator and experiment manager
+            if use_challenge:
+                # make sure the token is set
+                token = shell.shell_config.token_dt1
+                if token is None:
+                    raise UserError("Please set token using the command 'dts tok set'")
+                # get container specs from the challenges server
+                images = get_challenge_images(challenge=challenge, step=settings.step, token=token)
+                sim_spec = images["simulator"]
+                expman_spec = images["evaluator"]
+            elif parsed.simulation:
+                # load container specs from the environment configuration
+                sim_env = load_yaml(os.path.join(environment_dir, "sim_env.yaml"))
+                sim_spec = ImageRunSpec(
+                    docker_image(SIMULATOR_IMAGE, parsed.registry), environment=sim_env, ports=[]
+                )
+                expman_env = load_yaml(os.path.join(environment_dir, "exp_manager_env.yaml"))
+                expman_spec = ImageRunSpec(
+                    docker_image(EXPERIMENT_MANAGER_IMAGE, parsed.registry), environment=expman_env, ports=[]
+                )
 
-        # image names
+            # image names
+            bridge_image = docker_image(BRIDGE_IMAGE, parsed.registry)
+
         ros_image = docker_image(ROSCORE_IMAGE, parsed.registry)
-        bridge_image = docker_image(BRIDGE_IMAGE, parsed.registry)
         vnc_image = project.image(registry=parsed.registry, arch=local_arch, owner=username, extra="vnc")
 
         # define container and network names
@@ -528,12 +566,13 @@ class DTCommand(DTCommandAbs):
 
         # make sure these containers are not running
         # - agent docker engine
-        remove_if_running(agent_client, sim_container_name)
-        remove_if_running(agent_client, ros_container_name)
-        remove_if_running(agent_client, expman_container_name)
-        remove_if_running(agent_client, agent_container_name)
-        remove_if_running(agent_client, bridge_container_name)
+        if has_agent:
+            remove_if_running(agent_client, sim_container_name)
+            remove_if_running(agent_client, expman_container_name)
+            remove_if_running(agent_client, agent_container_name)
+            remove_if_running(agent_client, bridge_container_name)
         # - always local engine
+        remove_if_running(agent_client, ros_container_name)
         remove_if_running(local_client, vnc_container_name)
 
         # cleanup unused docker networks
@@ -560,25 +599,37 @@ class DTCommand(DTCommandAbs):
         #     return
 
         # configure ROS environment
-        if parsed.local:
-            ros_env = {
-                "ROS_MASTER_URI": f"http://{ros_container_name}:{AGENT_ROS_PORT}",
-            }
-            if parsed.simulation:
-                ros_env["VEHICLE_NAME"] = "agent"
-                ros_env["HOSTNAME"] = "agent"
+        if has_agent:
+            if parsed.local:
+                ros_env = {
+                    "ROS_MASTER_URI": f"http://{ros_container_name}:{AGENT_ROS_PORT}",
+                }
+                if parsed.simulation:
+                    ros_env["VEHICLE_NAME"] = "agent"
+                    ros_env["HOSTNAME"] = "agent"
+                else:
+                    ros_env["VEHICLE_NAME"] = duckiebot
+                    ros_env["HOSTNAME"] = duckiebot
             else:
-                ros_env["VEHICLE_NAME"] = duckiebot
-                ros_env["HOSTNAME"] = duckiebot
+                ros_env = {
+                    # TODO: use duckiebot_ip in the URL
+                    "ROS_MASTER_URI": f"http://{duckiebot}.local:{AGENT_ROS_PORT}",
+                }
         else:
             ros_env = {
-                # TODO: use duckiebot_ip in the URL
-                "ROS_MASTER_URI": f"http://{duckiebot}.local:{AGENT_ROS_PORT}",
+                "ROS_MASTER_URI": f"http://{ros_container_name}:{AGENT_ROS_PORT}",
+                "VEHICLE_NAME": "agent",
+                "HOSTNAME": "agent"
             }
 
         # update the docker images we will be using (if requested)
-        local_images = [expman_spec.image_name, sim_spec.image_name]
-        agent_images = [bridge_image, ros_image, agent_image]
+        if has_agent:
+            local_images = [expman_spec.image_name, sim_spec.image_name]
+            agent_images = [bridge_image, ros_image, agent_image]
+        else:
+            agent_images = []
+            local_images = [ros_image]
+
         if parsed.pull:
             # - pull no matter what
             for image in local_images:
@@ -605,22 +656,21 @@ class DTCommand(DTCommandAbs):
                         exit(1)
 
         # create a docker network to deploy the containers in
-        # noinspection PyBroadException
         try:
             dtslogger.info(f"Creating agent network '{agent_network_name}'...")
-            agent_network = agent_client.networks.create(agent_network_name, driver="bridge")
+            agent_network: Network = agent_client.networks.create(agent_network_name, driver="bridge")
             dtslogger.info(f"Agent network '{agent_network_name}' created successfully!")
         except Exception:
             error: str = traceback.format_exc()
             dtslogger.error(
-                "An error occurred while creating the agent network. " f"The error reads: {error}"
+                f"An error occurred while creating the agent network. The error reads: {error}"
             )
             return
 
         # make temporary directories
         # TODO: use python's temporary directory
         now: str = datetime.datetime.now().strftime("%d%b%y_%H_%M_%S")
-        tmpdir = os.path.join("/tmp", username, re.sub(r"[^\w]", "_", prog), now)
+        tmpdir = os.path.join("/tmp", username, re.sub(r"\W", "_", prog), now)
         os.makedirs(tmpdir, exist_ok=False)
 
         # - fifos directory
@@ -804,6 +854,15 @@ class DTCommand(DTCommandAbs):
                 "tty": True,
                 "user": uid,
             }
+
+            # open configuration
+            expman_config = yaml.safe_load(expman_params["environment"]["experiment_manager_parameters"])
+            # overwrite experiment manager timeouts
+            expman_config["timeout_initialization"] = INFTY
+            expman_config["timeout_regular"] = INFTY
+            # close configuration
+            expman_params["environment"]["experiment_manager_parameters"] = yaml.safe_dump(expman_config)
+
             # ---
             dtslogger.debug(
                 f"Running experiment manager container '{expman_container_name}' "
@@ -825,7 +884,7 @@ class DTCommand(DTCommandAbs):
             containers_to_monitor.append(expman_container)
             containers_to_monitor.append(sim_container)
 
-        else:
+        elif parsed.duckiebot:
             # we are running on a robot instead
 
             # - launch FIFOs bridge
@@ -846,6 +905,10 @@ class DTCommand(DTCommandAbs):
                 threading.Thread(
                     target=continuously_monitor, args=(agent_client, bridge_container_name), daemon=True
                 ).start()
+
+        else:
+            # no agent
+            pass
 
         if settings.ros:
             # run ROS core
@@ -872,13 +935,13 @@ class DTCommand(DTCommandAbs):
                     }
                 }
             # configure ROS core container's network
-            if parsed.local:
+            if parsed.duckiebot and not parsed.local:
+                # running on duckiebot, make ROS core container visible on the host network
+                ros_params["network_mode"] = "host"
+            else:
                 # local run, attach the ROS core container to the local agent network
                 ros_params["network"] = agent_network.name
                 ros_params["ports"] = {f"{AGENT_ROS_PORT}/tcp": ("0.0.0.0", AGENT_ROS_PORT)}
-            else:
-                # running on duckiebot, make ROS core container visible on the host network
-                ros_params["network_mode"] = "host"
             # ---
             dtslogger.debug(
                 f"Running ROS core container '{ros_container_name}' "
@@ -952,17 +1015,17 @@ class DTCommand(DTCommandAbs):
                 "mode": "rw",
             }
         # when running locally, we attach VNC to the agent's network
-        if parsed.local:
+        if parsed.duckiebot and not parsed.local:
+            # when running on the robot, let (local) VNC reach the host network to use ROS
+            if not running_on_mac:
+                vnc_params["network_mode"] = "host"
+        else:
             vnc_params["network"] = agent_network.name
             # when using --bind, specify the address
             if parsed.bind:
                 vnc_params["ports"] = {"8087/tcp": (parsed.bind, 0)}
             else:
                 vnc_params["ports"] = {"8087/tcp": ("127.0.0.1", 0)}
-        else:
-            # when running on the robot, let (local) VNC reach the host network to use ROS
-            if not running_on_mac:
-                vnc_params["network_mode"] = "host"
 
         # - mount code (from project (aka meat))
         # get local and remote paths to code
@@ -1043,68 +1106,90 @@ class DTCommand(DTCommandAbs):
 
         dtslogger.info("Starting attached container")
 
-        agent_env = load_yaml(os.path.join(environment_dir, "agent_env.yaml"))
-        if settings.ros:
-            agent_env = {
-                **ros_env,
-                **agent_env,
-            }
-            if duckiebot is not None:
-                agent_env.update({
-                    "VEHICLE_NAME": duckiebot,
-                    "HOSTNAME": duckiebot,
-                })
+        if has_agent:
+            agent_env = load_yaml(os.path.join(environment_dir, "agent_env.yaml"))
+            if settings.ros:
+                agent_env = {
+                    **ros_env,
+                    **agent_env,
+                }
+                if duckiebot is not None:
+                    agent_env.update({
+                        "VEHICLE_NAME": duckiebot,
+                        "HOSTNAME": duckiebot,
+                    })
 
-        if LOG_LEVELS[ContainerNames.NAME_AGENT] != Levels.LEVEL_NONE:
-            agent_env[ENV_LOGLEVEL] = LOG_LEVELS[ContainerNames.NAME_AGENT].value
+            if LOG_LEVELS[ContainerNames.NAME_AGENT] != Levels.LEVEL_NONE:
+                agent_env[ENV_LOGLEVEL] = LOG_LEVELS[ContainerNames.NAME_AGENT].value
 
-        # build agent (if needed)
-        # TODO: check if there is an image with name 'image_name', build one if not
+            # build agent (if needed)
+            # TODO: check if there is an image with name 'image_name', build one if not
 
-        # TODO: adapt this to 'code/build'
-        # # build VNC
-        # dtslogger.info(f"Running VNC...")
-        # vnc_namespace: SimpleNamespace = SimpleNamespace(
-        #     workdir=project.path,
-        #     username=username,
-        #     recipe=recipe.path,
-        #     # TODO: test this
-        #     # impersonate=uid,
-        #     build_only=True,
-        #     quiet=True,
-        # )
-        # dtslogger.debug(f"Calling command 'code/vnc' with arguments: {str(vnc_namespace)}")
-        # shell.include.code.vnc.command(shell, [], parsed=vnc_namespace)
-        # TODO: adapt this to 'code/build'
+            # TODO: adapt this to 'code/build'
+            # # build VNC
+            # dtslogger.info(f"Running VNC...")
+            # vnc_namespace: SimpleNamespace = SimpleNamespace(
+            #     workdir=project.path,
+            #     username=username,
+            #     recipe=recipe.path,
+            #     # TODO: test this
+            #     # impersonate=uid,
+            #     build_only=True,
+            #     quiet=True,
+            # )
+            # dtslogger.debug(f"Calling command 'code/vnc' with arguments: {str(vnc_namespace)}")
+            # shell.include.code.vnc.command(shell, [], parsed=vnc_namespace)
+            # TODO: adapt this to 'code/build'
 
-        # noinspection PyBroadException
-        try:
-            agent_container = launch_agent(
-                project=project,
-                agent_container_name=agent_container_name,
-                agent_volumes=agent_bind,
-                parsed=parsed,
-                agent_base_image=agent_image,
-                agent_network=agent_network,
-                agent_client=agent_client,
-                duckiebot=duckiebot,
-                agent_env=agent_env,
-                tmpdir=tmpdir,
-            )
+            # attach to the agent container if we are running one
 
-            containers_monitor.add(agent_container)
+            # noinspection PyBroadException
+            try:
+                agent_container = launch_agent(
+                    project=project,
+                    agent_container_name=agent_container_name,
+                    agent_volumes=agent_bind,
+                    parsed=parsed,
+                    agent_base_image=agent_image,
+                    agent_network=agent_network,
+                    agent_client=agent_client,
+                    agent_env=agent_env,
+                    tmpdir=tmpdir,
+                )
 
-            attach_cmd = "docker %sattach %s" % (
-                "" if parsed.local else f"-H {duckiebot}.local ",
-                agent_container_name,
-            )
-            start_command_in_subprocess(attach_cmd)
+                containers_monitor.add(agent_container)
 
-        except Exception:
-            if not user_terminated:
-                dtslogger.error(f"Attached container terminated:\n" f"{indent_block(traceback.format_exc())}\n")
-        finally:
-            clean_shutdown(containers_monitor, containers_to_monitor, stop_attached_container)
+                attach_cmd = "docker %s attach %s" % (
+                    "" if parsed.local else f"-H {duckiebot}.local ",
+                    agent_container_name,
+                )
+                start_command_in_subprocess(attach_cmd)
+
+            except Exception:
+                if not user_terminated:
+                    dtslogger.error(
+                        f"Attached container '{agent_container_name}' terminated:\n"
+                        f"{indent_block(traceback.format_exc())}\n"
+                    )
+            finally:
+                clean_shutdown(containers_monitor, containers_to_monitor, stop_attached_container)
+
+        else:
+
+            # if no agent, attach to VNC container
+
+            # noinspection PyBroadException
+            try:
+                attach_cmd = f"docker attach {vnc_container_name}"
+                start_command_in_subprocess(attach_cmd)
+            except Exception:
+                if not user_terminated:
+                    dtslogger.error(
+                        f"Attached container '{vnc_container_name}' terminated:\n"
+                        f"{indent_block(traceback.format_exc())}\n"
+                    )
+            finally:
+                clean_shutdown(containers_monitor, containers_to_monitor, stop_attached_container)
 
         dtslogger.info(f"All done, your results are available in: {challenges_dir}")
 
@@ -1246,7 +1331,6 @@ def launch_agent(
     agent_base_image: str,
     agent_network,
     agent_client: DockerClient,
-    duckiebot: str,
     agent_env: Dict[str, str],
     tmpdir: str,
 ):
@@ -1439,25 +1523,36 @@ def get_calibration_files(destination_dir, duckiebot):
     dtslogger.info("Getting all calibration files")
 
     calib_files = [
-        "config/calibrations/camera_intrinsic/{duckiebot:s}.yaml",
-        "config/calibrations/camera_extrinsic/{duckiebot:s}.yaml",
-        "config/calibrations/kinematics/{duckiebot:s}.yaml",
+        "config/calibrations/camera_intrinsic/{name:s}.yaml",
+        "config/calibrations/camera_extrinsic/{name:s}.yaml",
+        "config/calibrations/kinematics/{name:s}.yaml",
     ]
 
     for calib_file in calib_files:
-        calib_file = calib_file.format(duckiebot=duckiebot)
-        url = "http://{:s}.local/files/data/{:s}".format(duckiebot, calib_file)
+        calib_fpath = calib_file.format(name=duckiebot)
+        url = "http://{:s}.local/files/data/{:s}".format(duckiebot, calib_fpath)
         # get calibration using the files API
         dtslogger.debug('Fetching file "{:s}"'.format(url))
         res = requests.get(url, timeout=10)
         if res.status_code != 200:
-            dtslogger.warn(
+            dtslogger.error(
                 "Could not get the calibration file {:s} from robot {:s}. Is it calibrated? "
-                "".format(calib_file, duckiebot)
+                "Getting default calibration instead."
+                "".format(calib_fpath, duckiebot)
             )
-            continue
+            # get default calibration using the files API
+            calib_fpath = calib_file.format(name="default")
+            url = "http://{:s}.local/files/data/{:s}".format(duckiebot, calib_fpath)
+            dtslogger.debug('Fetching file "{:s}"'.format(url))
+            res = requests.get(url, timeout=10)
+            if res.status_code != 200:
+                dtslogger.fatal(
+                    "Could not get the default calibration file {:s} from robot {:s}. This should not have "
+                    "happened. Skipping this calibration.".format(calib_fpath, duckiebot)
+                )
+                continue
         # make destination directory
-        dirname = os.path.join(destination_dir, os.path.dirname(calib_file))
+        dirname = os.path.join(destination_dir, os.path.dirname(calib_fpath))
         if not os.path.isdir(dirname):
             dtslogger.debug('Creating directory "{:s}"'.format(dirname))
             os.makedirs(dirname)
@@ -1465,7 +1560,7 @@ def get_calibration_files(destination_dir, duckiebot):
         # Also save them to specific robot name for local evaluation
         destination_file = os.path.join(dirname, f"{duckiebot}.yaml")
         dtslogger.debug(
-            'Writing calibration file "{:s}:{:s}" to "{:s}"'.format(duckiebot, calib_file, destination_file)
+            'Writing calibration file "{:s}:{:s}" to "{:s}"'.format(duckiebot, calib_fpath, destination_file)
         )
         with open(destination_file, "wb") as fd:
             for chunk in res.iter_content(chunk_size=128):

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -80,7 +80,7 @@ def get_user_login() -> str:
     try:
         user = os.getlogin()
     # fall back on getpass for terminals not registering with utmp
-    except FileNotFoundError:
+    except (OSError, FileNotFoundError):
         import getpass
         user = getpass.getuser()
     return user

--- a/utils/yaml_utils.py
+++ b/utils/yaml_utils.py
@@ -1,10 +1,12 @@
+from typing import Union
+
 import os
 import yaml
 
 __all__ = ["load_yaml"]
 
 
-def load_yaml(file_name: str) -> dict:
+def load_yaml(file_name: str) -> Union[dict, list, bytes, float, int, None]:
     if not os.path.isfile(file_name):
         msg = f"File does not exist {file_name}"
         raise Exception(msg)


### PR DESCRIPTION
* fixed #389

* Added no simulator nor duckiebot option

Launching without either `--simulation` or `--duckiebot` flags will start a simple vnc environment with ROS.

* Fixed bugs

* DTSW-2460: Override experiment manager timeout for VNC (#403)

* code/workbench: added timeout update to experiment manager configuration

* Make infinity less infinite

* Rem prints

---------



* more robust parsing of params

* Installin CA from the $CAROOT directory if it exists DTSW-3195

* Moved installation flag

* Moved ca_flag location

* Fixed bug

* Moving uninstall before environment variable check

* Improved setup for mkcert

* Fixed bug

* Fixed bug

* Improvements to the command logic

* Fixed bug

* Fixing bug pt 2

* Still fixing

* Improvements to uninstall and info logging

* Revert "Fixed bugs"

This reverts commit 93505d07d4069f125b401c0d01e3c0ac7f3638c6.

* Revert "Added no simulator nor duckiebot option"

This reverts commit 91ba102b82be85b941f21696becb84ca3cfd0155.

* code/workbench: re-implementing no-agent behavior

* Skipping pulling agent images

* Get agent's images only if agent is required

* Fixing removal of agent containers if no agent is running

* Create agent network only if agent is requested

* Run ros even if there is no agent

* Syncing code only if there is an agent

* Fixed removing running containers

* minor

* code/workbench: restructured ROS configuration

* Recreate network

* code/workbench: fixed bug with missing calibrations

* Attaching containers to correct networks

* Fixing VNC port attachment

* code/workbench: formatting

* code/workbench: bug fix

* Do not get challenge file if there is no agent

* Reverting previous commit

---------