### PR TITLE
Add command to flash HUT

### DIFF
--- a/duckiebot/hut_upgrade/__init__.py
+++ b/duckiebot/hut_upgrade/__init__.py
@@ -1,0 +1,52 @@
+# This is a default __init__ file for the Duckietown Shell commands
+#
+# Maintainer: Andrea F. Daniele
+from os.path import (
+    exists as _exists,
+    dirname as _dirname,
+    basename as _basename,
+    isdir as _isdir,
+    isfile as _isfile,
+    relpath as _relpath,
+    join as _join,
+)
+import glob as _glob
+
+from dt_shell import dtslogger
+
+import utils
+from utils.exceptions import ShellNeedsUpdate
+
+# constants
+_this_dir = _dirname(__file__)
+_command_file = "command.py"
+
+# import current command
+if _exists(_join(_this_dir, _command_file)):
+    try:
+        # noinspection PyUnresolvedReferences
+        from .command import *
+    except ShellNeedsUpdate as e:
+        _root: str = _join(_dirname(utils.__file__), "..")
+        _command: str = _relpath(_this_dir, _root).strip("/")
+        dtslogger.warning(
+            f"Command '{_command}' was not loaded because the shell needs to be "
+            f"updated. Current version is {e.current_version}, required version is "
+            f"{e.version_needed}"
+        )
+        from utils.command_utils import failed_to_load_command as command
+
+# find all modules
+_modules = [m for m in _glob.glob(_join(_this_dir, "*")) if _isdir(m)]
+# this is important to avoid name clashing with commands at lower levels
+_modules.sort(key=lambda p: int(_isfile(_join(p, _command_file))))
+
+# load submodules
+for _mod in _modules:
+    try:
+        exec("from .%s import *" % _basename(_mod))
+    except ImportError as e:
+        if _exists(_join(_mod, _command_file)):
+            raise EnvironmentError(e)
+    except EnvironmentError as e:
+        raise e

--- a/duckiebot/hut_upgrade/command.py
+++ b/duckiebot/hut_upgrade/command.py
@@ -1,0 +1,99 @@
+import argparse
+
+from docker.errors import APIError, ImageNotFound
+
+from dt_shell import DTCommandAbs, DTShell, dtslogger
+from utils.cli_utils import start_command_in_subprocess
+from utils.docker_utils import get_client, get_endpoint_architecture, pull_image
+from utils.duckietown_utils import get_distro_version
+from utils.misc_utils import sanitize_hostname
+from utils.robot_utils import log_event_on_robot
+
+
+UPGRADE_IMAGE = "duckietown/dt-firmware-upgrade:{distro}-{arch}"
+UPGRADE_LAUNCHER = "dt-launcher-flash-hut"
+DOCKER_CONTAINER_NAME = "dts-hut-firmware-upgrade"
+DEBUG = 0
+
+
+class DTCommand(DTCommandAbs):
+    help = "Upgrades a Duckiebot's HUT firmware"
+
+    @staticmethod
+    def command(shell: DTShell, args):
+        prog = "dts duckiebot hut_upgrade"
+
+        # parse cmd-line options
+        parser = argparse.ArgumentParser(prog=prog)
+        parser.add_argument("--image", default=None, help="Specific docker image to use (skip pulling)")
+        parser.add_argument("duckiebot", default=None, help="Name of the Duckiebot")
+        parsed = parser.parse_args(args)
+
+        # retrieve robot hostname and the docker endpoint
+        hostname = sanitize_hostname(parsed.duckiebot)
+        client = get_client(hostname)
+
+        # pull default image, or use specifed local image
+        if parsed.image is None:
+            # default image to use
+            arch = get_endpoint_architecture(hostname)
+            distro = get_distro_version(shell)
+            image = UPGRADE_IMAGE.format(distro=distro, arch=arch)
+
+            dtslogger.info(f'Pulling image "{image}" on [{hostname}]')
+            # Try pulling the latest dt-firmware-upgrade image
+            try:
+                pull_image(image, endpoint=client)
+            except KeyboardInterrupt:
+                dtslogger.info("Aborting.")
+                return
+            except Exception as e:
+                dtslogger.error(f'An error occurred while pulling the image "{image}": {str(e)}')
+                exit(1)
+            dtslogger.info(f'The image "{image}" is now up-to-date.')
+        else:
+            # use specified image
+            image = parsed.image
+            # ensure it is available
+            try:
+                _ = client.images.get(image)
+            except ImageNotFound:
+                dtslogger.error(f'The specified image is not present on host [{hostname}]: "{image}"')
+                exit(1)
+            except APIError as e:
+                dtslogger.error(str(e))
+                exit(1)
+            dtslogger.info(f'Using the existing image of "{image}" on [{hostname}]')
+
+        # log hut upgrade event
+        log_event_on_robot(hostname, "hut/upgrade")
+
+        # perform upgrade
+        dtslogger.info("Updating HUT...")
+        try:
+            _ = client.containers.run(
+                image=image,
+                name=DOCKER_CONTAINER_NAME,
+                command=UPGRADE_LAUNCHER,
+                privileged=True,
+                auto_remove=True,
+                environment={"DEBUG": DEBUG},
+                detach=True,
+                # interactive
+                stdin_open=True,
+                tty=True,
+                # mount data folder for recognizing robot computer type
+                volumes=["/data:/data"],
+            )
+            # attach to the interactive container
+            attach_cmd = f"docker -H {hostname} attach {DOCKER_CONTAINER_NAME}"
+            start_command_in_subprocess(attach_cmd)
+
+            dtslogger.info("Upgrade finished successfully. Please reboot your Duckiebot now.")
+        except APIError as e:
+            dtslogger.error(f"Docker client error: {str(e)}")
+            exit(1)
+        except Exception as e:
+            # other errors and by user cancellation
+            dtslogger.error("Unable to finish the upgrade.")
+            exit(1)


### PR DESCRIPTION
Command added:
```
usage: dts duckiebot hut_upgrade [-h] [--image IMAGE] duckiebot

positional arguments:
  duckiebot      Name of the Duckiebot

optional arguments:
  -h, --help     show this help message and exit
  --image IMAGE  Specific docker image to use (skip pulling)
```

### Example use 1
* when called without `--image`, the command tries to pull and use the default image
* when called with `--image`, the command uses the local specified image
* the screencast shows the interactions and the outputs of a successful HUT flash

https://github.com/duckietown/duckietown-shell-commands/assets/10885835/7e7f3360-d3b8-431b-9ebb-a2e3f4c795b8

### Example use 2
When the user depicts the intermediate checkpoints as failed, the operation is aborted.

https://github.com/duckietown/duckietown-shell-commands/assets/10885835/54b049c2-e457-4b9f-9d53-9fbc38f7fb0c

