### PR TITLE
Replace duplicate duckietown network configuration with placeholder for netplan

### DIFF
--- a/init_sd_card/command.py
+++ b/init_sd_card/command.py
@@ -816,7 +816,11 @@ def _get_netplan_wifi_configuration(parsed) -> str:
     wifis = []
 
     for connection in networks:
-        # EAP-secured network
+        if connection.ssid == "duckietown" and connection.psk == "quackquack":
+            # Replace the duckietown:quackquack network with a placeholder. This network is already included
+            # in the base disk image and should not be added again to avoid a duplicate in the netplan configuration file.
+            connection = _interpret_wifi_string("mywifi:mypassword")[0]
+
         if connection.username is not None:
             wifi = NETPLAN_WPA_EAP_NETWORK_CONFIG.format(
                 ssid=connection.ssid,


### PR DESCRIPTION
The base image `v4.0.0` for raspberry pi 64 uses netplan. By default there is a network configuration file in `/configfs/wifi/99-duckietown.yaml` that configures the wifi network with ssid `duckietown` and password `quackquack`. However when the user doe no provide `dts init_sd_card` the `--wifi` flag with a user-defined wifi configuration (in the format `ssid:psk`) it defaults to `duckietown:quackquack`. This is parsed and added to the `/configfs/wifi/00-user.yaml`. When netplan parses both files it detects a duplicate and stops, thus no wifi network configuration is enabled. In the PR if the `duckietown:quackquack` network is detected in the parsed inputs it is replaced with a placeholder (`my-wifi:my-password`) and added to the `00-user.yaml` netplan configuration. This prevents generating a duplicate and thus a configuration conflict.