### PR TITLE
Add robot hardware argument to dts duckiebot update and create duckiebot-orin stack configuration

### DIFF
--- a/duckiebot/update/command.py
+++ b/duckiebot/update/command.py
@@ -61,6 +61,9 @@ class DTCommand(DTCommandAbs):
         parser.add_argument(
             "-t", "--robot-type", type=str, default=None, help="Force using a specific robot type (the -f flag MUST also be selected)"
         )
+        parser.add_argument(
+            "--robot-hardware", type=str, default=None, help="Force using a specific robot hardware (the -f flag MUST also be selected)"
+        )
 
         parser.add_argument("robot", nargs=1, help="Name of the Robot to update")
         # parse arguments
@@ -80,14 +83,17 @@ class DTCommand(DTCommandAbs):
 
         # get the robot type
         rtype: Optional[str]
+        robot_hardware: Optional[str]
         if kv.is_available():
             rtype = kv.get(str, "robot/type", None)
+            robot_hardware = kv.get(str, "robot/hardware", None)
         else:
+            robot_hardware = None
             rtype = None
 
         if rtype is None and parsed.robot_type is None:
             dtslogger.warning(f"Could not get the robot type from robot '{robot}'")
-            rtype: Optional[str] = questionary.select(
+            rtype = questionary.select(
                 "Select robot type:", choices=["duckiebot", "duckiedrone"]
             ).unsafe_ask()
             if rtype is None:
@@ -100,10 +106,29 @@ class DTCommand(DTCommandAbs):
             
         assert rtype is not None
 
+        if robot_hardware is None and parsed.robot_hardware is None:
+            dtslogger.warning(f"Could not get the robot hardware from robot '{robot}'")
+            robot_hardware = questionary.select(
+                "Enter robot hardware:",
+                choices=["jetson_orin_nano", "jetson_nano", "raspberry_pi_64", "raspberry_pi", "virtual"],
+            ).unsafe_ask()
+            if not robot_hardware:
+                raise UserAborted()
+            dtslogger.info(f"Declared robot hardware: {robot_hardware}")
+        elif parsed.force and parsed.robot_hardware is not None:
+            robot_hardware = parsed.robot_hardware
+        else:
+            dtslogger.info(f"Detected robot hardware: {robot_hardware}")
+
         # replace the placeholder in the stacks
         resolved_stacks: Dict[str, str] = {}
+        
         for project, stack_fmt in stacks.items():
-            resolved_stacks[project] = stack_fmt.format(robot_type=rtype)
+            if robot_hardware == "jetson_orin_nano" and project == "duckietown":
+                stack_fmt = stack_fmt.replace("{robot_type}", "duckiebot-orin")
+            else:
+                stack_fmt = stack_fmt.format(robot_type=rtype)
+            resolved_stacks[project] = stack_fmt
         stacks = resolved_stacks
 
         # check whether the robot is using a different distro

--- a/stack/stacks/duckietown/duckiebot-orin.yaml
+++ b/stack/stacks/duckietown/duckiebot-orin.yaml
@@ -1,0 +1,279 @@
+version: '3.2'
+services:
+
+  dtps:
+    image: ${REGISTRY}/duckietown/dtps-switchboard:release
+    container_name: dtps
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      RUST_LOG: "warn,dtps_http=info"
+    command: --tcp-port 11511 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
+    privileged: true
+    volumes:
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-camera:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-camera
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    pid: host
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-camera
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+      # nvargus socket
+      - /tmp:/tmp
+
+  driver-tof:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-tof
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-tof
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-imu:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-imu
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-imu
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-power-button:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-power-button
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-power-button
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-wheel-encoders:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-wheel-encoders
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-wheel-encoders
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-wheels:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-wheels
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: actuator-wheels
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-lights:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-lights
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: actuator-lights
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-display:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-display
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: actuator-display
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  control-mapper:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: control-mapper
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: control-mapper
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 10
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  dashboard:
+    image: ${REGISTRY}/duckietown/dt-device-dashboard:ente-${ARCH}
+    container_name: dashboard
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      HTTP_PORT: 8080
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # secrets
+      - /secrets:/secrets
+      # compose volume
+      - compose-data:/user-data/databases
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  files-api:
+    image: ${REGISTRY}/duckietown/dt-files-api:ente-${ARCH}
+    container_name: files-api
+    restart: always
+    network_mode: host
+    privileged: true
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # secrets
+      - /secrets:/secrets
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  code-api:
+    image: ${REGISTRY}/duckietown/dt-code-api:ente-${ARCH}
+    container_name: code-api
+    restart: always
+    network_mode: host
+    privileged: true
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # user code
+      - /code:/user_code
+      # docker socket
+      - /var/run/docker.sock:/var/run/docker.sock
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  device-proxy:
+    image: ${REGISTRY}/duckietown/dt-device-proxy:ente-${ARCH}
+    container_name: device-proxy
+    restart: always
+    network_mode: host
+    environment:
+      DT_SUPERUSER: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  device-health:
+    image: ${REGISTRY}/duckietown/dt-device-health:ente-${ARCH}
+    container_name: device-health
+    restart: always
+    network_mode: host
+    privileged: true
+    environment:
+      # needed to talk to the docker daemon socket
+      DT_SUPERUSER: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # triggers
+      - /triggers:/triggers
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  device-online:
+    image: ${REGISTRY}/duckietown/dt-device-online:ente-${ARCH}
+    container_name: device-online
+    restart: always
+    network_mode: host
+    # needed to run threads in Python3.12 (https://forums.docker.com/t/runtimeerror-cant-start-new-thread/138142/2)
+    privileged: true
+    environment:
+      # needed to talk to the docker daemon socket
+      DT_SUPERUSER: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # secrets
+      - /secrets:/secrets
+      # docker socket
+      - /var/run/docker.sock:/var/run/docker.sock
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+volumes:
+  compose-data:

--- a/stack/stacks/duckietown/duckiebot-orin.yaml
+++ b/stack/stacks/duckietown/duckiebot-orin.yaml
@@ -17,7 +17,7 @@ services:
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
   driver-camera:
-    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}-orin
     container_name: driver-camera
     restart: unless-stopped
     network_mode: host


### PR DESCRIPTION
The Nvidia Jetson Orin necessitates using a different image for the camera stack due to an incompatibility between the Jetson Nano and the Jetson Orin Nano libraries.