### PR TITLE
Fix: address-cells placement and reorder mux@70 properties

### DIFF
--- a/disk_image/create/jetson_nano/disk_template/APP/boot/duckietown_front_bumper_2_v1.dts
+++ b/disk_image/create/jetson_nano/disk_template/APP/boot/duckietown_front_bumper_2_v1.dts
@@ -15,7 +15,6 @@
                 compatible = "ti,tca9548a", "ti,tca9548", "nxp,pca9548";
                 reg = <0x70>;
                 vcc-pullup-supply = <0x4b>;
-                status = "okay";
                 vcc-supply = <0x4b>;
                 status = "okay";
             };

--- a/disk_image/create/jetson_nano/disk_template/APP/boot/duckietown_front_bumper_2_v1.dts
+++ b/disk_image/create/jetson_nano/disk_template/APP/boot/duckietown_front_bumper_2_v1.dts
@@ -9,14 +9,15 @@
         target-path = "/i2c@7000c400";
 
         __overlay__ {
+            #address-cells = <0x1>;
+            #size-cells = <0x0>;
             mux@70 {
                 compatible = "ti,tca9548a", "ti,tca9548", "nxp,pca9548";
+                reg = <0x70>;
                 vcc-pullup-supply = <0x4b>;
                 status = "okay";
-                #address-cells = <0x1>;
-                #size-cells = <0x0>;
                 vcc-supply = <0x4b>;
-                reg = <0x70>;
+                status = "okay";
             };
         };
     };


### PR DESCRIPTION
Fixes warnings from `dtc` by moving `#address-cells` and `#size-cells` from inside `mux@70` to the parent `__overlay__ node`, matching the I2C bus format. It also reorders properties in `mux@70` to follow Device Tree conventions (with `reg` and `compatible` first), improving readability and maintainability.