### PR TITLE
prevents removal of containers specified by stacks in same subfolder

### DIFF
--- a/stack/up/command.py
+++ b/stack/up/command.py
@@ -106,8 +106,11 @@ class DTCommand(DTCommandAbs):
         dtslogger.info(f"Running stack [{project_name}]({stack})...")
         print("------>")
         # collect arguments
+        #docker_arguments = [
+        #    "--remove-orphans",
+        #]
         docker_arguments = [
-            "--remove-orphans",
+            "--detach",
         ]
         # get copy of environment
         env = {}


### PR DESCRIPTION
The `remove-orphans` flag will kill any containers in the current project when you do `dts stack up` , and since the folder name is the project name, it will kill any other containers. E.g. if you do something like `dts stack up ROBOT robot/duckiematrix` that will bring down the `kvstore` and `portainer` containers because they are also in the robot folder. Removing this flag is a quick hack to solve that before we refactor the stacks. It could be causing some unexpected behaviours I think which are resulting from the removal of the explicit `project_name` flag.