### PR TITLE
Update TCP port for DTPS to 11911 to fix conflict with ROS2 RPC daemon

### DIFF
--- a/duckiebot/dtps/command.py
+++ b/duckiebot/dtps/command.py
@@ -11,7 +11,7 @@ class DTCommand(DTCommandAbs):
         parsed = kwargs.get("parsed", None)
         if parsed is None:
             parsed = DTCommand.parser.parse_args(args)
-        port = 11411 if parsed.kv_store else 11511
+        port = 11411 if parsed.kv_store else 11911
         topic = parsed.topic.strip("/") if parsed.topic else ""
         if topic:
             topic += "/"

--- a/stack/stacks/duckietown/duckiebot-orin.yaml
+++ b/stack/stacks/duckietown/duckiebot-orin.yaml
@@ -7,7 +7,7 @@ services:
     network_mode: host
     environment:
       RUST_LOG: "warn,dtps_http=info"
-    command: --tcp-port 11511 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
+    command: --tcp-port 11911 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
     privileged: true
     volumes:
       # dtps sockets

--- a/stack/stacks/duckietown/duckiebot.yaml
+++ b/stack/stacks/duckietown/duckiebot.yaml
@@ -7,7 +7,7 @@ services:
     network_mode: host
     environment:
       RUST_LOG: "warn,dtps_http=info"
-    command: --tcp-port 11511 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
+    command: --tcp-port 11911 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
     privileged: true
     volumes:
       # dtps sockets

--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -7,7 +7,7 @@ services:
     network_mode: host
     environment:
       RUST_LOG: "warn,dtps_http=info"
-    command: --tcp-port 11511 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
+    command: --tcp-port 11911 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
     privileged: true
     volumes:
       # dtps sockets

--- a/stack/stacks/duckietown/traffic_light.yaml
+++ b/stack/stacks/duckietown/traffic_light.yaml
@@ -7,7 +7,7 @@ services:
     network_mode: host
     environment:
       RUST_LOG: "warn,dtps_http=info"
-    command: --tcp-port 11511 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
+    command: --tcp-port 11911 --tcp-host 0.0.0.0 --unix-path /dtps/switchboard.sock
     privileged: true
     volumes:
       # dtps sockets

--- a/stack/stacks/ros2/duckiebot.yaml
+++ b/stack/stacks/ros2/duckiebot.yaml
@@ -111,8 +111,6 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      # avahi socket
-      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
   rosbridge-websocket:
     image: ${REGISTRY}/duckietown/dt-ros2bridge-websocket:ente-${ARCH}


### PR DESCRIPTION
## Description of changes
- Identified the current DTPS port binding (11511) and confirm the conflict with ROS 2 discovery.

- Updated DTPS configuration to use port 11911 instead.

- Tested ROS 2 topic discovery after the change to ensure no communication issues.

## How to test
Bring down the duckietown and ROS1 stacks:

```
dts stack down duckietown/duckiebot -H ROBOT_NAME
dts stack down ros1/duckiebot -H ROBOT_NAME
```

Bring up the duckietown and ROS2 stacks:

```
dts stack up duckietown/duckiebot -H ROBOT_NAME
dts stack up ros2/duckiebot -H ROBOT_NAME
```

Attach a shell to the `ros2-camera` container and verify that `ros2 topic list` works.

