### PR TITLE
Add security options to ROS2 stack configurations to fix numpy import

### DIFF
--- a/stack/stacks/ros2/duckiebot.yaml
+++ b/stack/stacks/ros2/duckiebot.yaml
@@ -6,6 +6,8 @@ services:
     restart: unless-stopped
     network_mode: host
     pid: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: sensor-camera
       DT_SUPERUSER: 1
@@ -19,6 +21,8 @@ services:
     container_name: ros2-tof
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: sensor-tof
       DT_SUPERUSER: 1
@@ -32,6 +36,8 @@ services:
     container_name: ros2-imu
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: sensor-imu
       DT_SUPERUSER: 1
@@ -45,6 +51,8 @@ services:
     container_name: ros2-power-button
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: sensor-power-button
       DT_SUPERUSER: 1
@@ -58,6 +66,8 @@ services:
     container_name: ros2-wheel-encoders
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: sensor-wheel-encoders
       DT_SUPERUSER: 1
@@ -71,6 +81,8 @@ services:
     container_name: ros2-wheels
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: actuator-wheels
       DT_SUPERUSER: 1
@@ -84,6 +96,8 @@ services:
     container_name: ros2-leds
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: actuator-leds
       DT_SUPERUSER: 1
@@ -97,6 +111,8 @@ services:
     container_name: ros2-display
     restart: unless-stopped
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_LAUNCHER: actuator-display
       DT_SUPERUSER: 1
@@ -131,6 +147,8 @@ services:
     container_name: car-interface
     restart: always
     network_mode: host
+    security_opt:
+      - seccomp=unconfined
     environment:
       DT_SUPERUSER: 1
     volumes:


### PR DESCRIPTION
Simple fix to solve `numpy` not importing