### PR TITLE
Ente-DTSW-7210-Add-profiler-options

### DIFF
--- a/matrix/engine/run/command.py
+++ b/matrix/engine/run/command.py
@@ -177,6 +177,9 @@ class MatrixEngine:
         # (Linux only) use network mode host
         if platform.system() == "Linux" and not parsed.expose_ports:
             engine_config["network_mode"] = "host"
+        # profiler
+        if parsed.profiler:
+            engine_config["command"] += ["--profiler"]
         # run engine container
         dtslogger.debug(engine_config)
         self.config = engine_config

--- a/matrix/engine/run/configuration.py
+++ b/matrix/engine/run/configuration.py
@@ -94,6 +94,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             action="store_true",
             help="Run in verbose mode"
         )
+        parser.add_argument(
+            "--profiler",
+            default=False,
+            action="store_true",
+            help="Enable the profiler"
+        )
         # ---
         return parser
 

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -150,6 +150,12 @@ class DTCommand(DTCommandAbs):
             action="store_true",
             help="Disable showing the tutorial"
         )
+        parser.add_argument(
+            "--profiler",
+            default=False,
+            action="store_true",
+            help="Enable the profiler (requires -S/--standalone)"
+        )
         parsed, _ = parser.parse_known_args(args=args)
         return parsed
 
@@ -185,6 +191,10 @@ class DTCommand(DTCommandAbs):
         #     dtslogger.error("You can specify a --delta-t only when running with "
         #                     "--gym/--simulation.")
         #     return
+        # profiler
+        if parsed.profiler and not run_engine:
+            dtslogger.error("You cannot use --profiler without -S/--standalone.")
+            return
         # configure the engine if in standalone
         engine: Optional[MatrixEngine] = None
         if run_engine:
@@ -239,6 +249,8 @@ class DTCommand(DTCommandAbs):
                 pass
             else:
                 app_config += ["--tutorial"]
+            if parsed.profiler:
+                app_config += ["--profiler"]
             # token
             app_config += ["--token", shell.profile.secrets.dt_token]
             # ---


### PR DESCRIPTION
This pull request adds support for enabling a profiler when running the engine in standalone mode. The main changes include introducing a new `--profiler` command-line argument and updating the engine configuration to handle this option. Additionally, validation is added to ensure the profiler can only be activated in standalone mode.

**Profiler feature integration:**

* Added a `--profiler` argument to the command-line interface in both `matrix/run/command.py` and `matrix/engine/run/configuration.py`, allowing users to enable the profiler when running commands. [[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR153-R158) [[2]](diffhunk://#diff-0b281844232a646fab546d2a57f5d407a51cc23b423eff8a342696f6a835d4cfR97-R102)
* Updated the engine configuration in `matrix/engine/run/command.py` to append the `--profiler` flag to the engine command if the profiler option is enabled.

**Validation and error handling:**

* Implemented a check in `matrix/run/command.py` to ensure that the `--profiler` option can only be used when running in standalone mode, displaying an error otherwise.