### PR TITLE
Ente-DTSW-7108-Add-a-browser-option-for-the-Duckietown-Viewer

### DIFF
--- a/duckiebot/calibrate_extrinsics/command.py
+++ b/duckiebot/calibrate_extrinsics/command.py
@@ -27,6 +27,7 @@ class DTCommand(DTCommandAbs):
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
+            browser=parsed.browser,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/calibrate_extrinsics/configuration.py
+++ b/duckiebot/calibrate_extrinsics/configuration.py
@@ -51,6 +51,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable hardware acceleration"
         )
         parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
             "robot",
             help="Name of the robot to connect to"
         )

--- a/duckiebot/calibrate_intrinsics/command.py
+++ b/duckiebot/calibrate_intrinsics/command.py
@@ -27,6 +27,7 @@ class DTCommand(DTCommandAbs):
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
+            browser=parsed.browser,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/calibrate_intrinsics/configuration.py
+++ b/duckiebot/calibrate_intrinsics/configuration.py
@@ -51,6 +51,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable hardware acceleration"
         )
         parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
             "robot",
             help="Name of the robot to connect to"
         )

--- a/duckiebot/image_viewer/command.py
+++ b/duckiebot/image_viewer/command.py
@@ -27,6 +27,7 @@ class DTCommand(DTCommandAbs):
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
+            browser=parsed.browser,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/image_viewer/configuration.py
+++ b/duckiebot/image_viewer/configuration.py
@@ -51,6 +51,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable hardware acceleration"
         )
         parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
             "robot",
             help="Name of the robot to connect to"
         )

--- a/duckiebot/keyboard_control/command.py
+++ b/duckiebot/keyboard_control/command.py
@@ -30,6 +30,7 @@ class DTCommand(DTCommandAbs):
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
+            browser=parsed.browser,
             window_args={
                 "height": 418,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/keyboard_control/configuration.py
+++ b/duckiebot/keyboard_control/configuration.py
@@ -47,6 +47,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable hardware acceleration"
         )
         parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
             "robot",
             help="Name of the robot to control"
         )

--- a/duckiebot/led_control/command.py
+++ b/duckiebot/led_control/command.py
@@ -27,6 +27,7 @@ class DTCommand(DTCommandAbs):
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
+            browser=parsed.browser,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/led_control/configuration.py
+++ b/duckiebot/led_control/configuration.py
@@ -51,6 +51,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable hardware acceleration"
         )
         parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
             "robot",
             help="Name of the robot to connect to"
         )

--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -209,7 +209,8 @@ class DuckietownViewerInstance:
             self._wait_backend_ready()
         if browser:
             url = f"http://{self._backend_ip}:{self._BACKEND_REMOTE_PORT}/app/"
-            webbrowser.open(url)
+            if not webbrowser.open(url):
+                dtslogger.warning("Could not open browser.")
             dtslogger.info(f"Navigate to {url}")
             try:
                 while True:

--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Union, Dict
 
 import dockertown
 import requests
+import webbrowser
 from dockertown import Container
 from dockertown import DockerClient
 from dockertown.exceptions import NoSuchContainer
@@ -176,10 +177,10 @@ def ensure_duckietown_viewer_installed(log_prefix: str = None):
     dtslogger.info(f"{log_prefix}Installation completed successfully!")
 
 
-def launch_viewer(app: str, *, robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, window_args: Optional[WindowArgs] = None) \
+def launch_viewer(app: str, *, robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, browser: bool = False, window_args: Optional[WindowArgs] = None) \
         -> 'DuckietownViewerInstance':
     viewer = DuckietownViewerInstance(verbose=verbose)
-    viewer.start(app, robot, fullscreen, menu, on_top, enable_hardware_acceleration, window_args=window_args)
+    viewer.start(app, robot, fullscreen, menu, on_top, enable_hardware_acceleration, browser, window_args=window_args)
     return viewer
 
 
@@ -202,12 +203,22 @@ class DuckietownViewerInstance:
         self._frontend: Optional[subprocess.Popen] = None
         self._backend_ip: Optional[str] = None
 
-    def start(self, app: str, robot: Optional[str], fullscreen: Optional[bool], menu: Optional[bool], on_top: Optional[bool], enable_hardware_acceleration: Optional[bool], window_args: Optional[WindowArgs] = None):
+    def start(self, app: str, robot: Optional[str], fullscreen: Optional[bool], menu: Optional[bool], on_top: Optional[bool], enable_hardware_acceleration: Optional[bool], browser: bool = False, window_args: Optional[WindowArgs] = None):
         if "url" not in window_args.keys():
             self._start_backend(app, robot)
             self._wait_backend_ready()
-        self._start_frontend(fullscreen, menu, on_top, enable_hardware_acceleration, window_args or {})
-        self._join_frontend()
+        if browser:
+            url = f"http://{self._backend_ip}:{self._BACKEND_REMOTE_PORT}/app/"
+            webbrowser.open(url)
+            dtslogger.info(f"Navigate to {url}")
+            try:
+                while True:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                dtslogger.info("Exiting...")
+        else:
+            self._start_frontend(fullscreen, menu, on_top, enable_hardware_acceleration, window_args or {})
+            self._join_frontend()
         self._stop()
 
     def _start_backend(self, app: str, robot: str):


### PR DESCRIPTION
This pull request adds support for a "browser mode" across several Duckiebot applications, allowing users to optionally launch the Duckietown Viewer in their web browser instead of a native window. The changes affect both the command-line argument parsing and the viewer launch logic, ensuring a consistent experience across calibration, image viewing, keyboard, and LED control tools.

### Browser mode support

* Added a new `--browser` command-line argument to the parsers in `configuration.py` for calibrate extrinsics, calibrate intrinsics, image viewer, keyboard control, and LED control modules, enabling users to specify browser mode. [[1]](diffhunk://#diff-29ec1ccac97f8a17602434b417717a14ab9902271954d64c609a05a77652689aR53-R58) [[2]](diffhunk://#diff-3a841b3192eaec6f6870069a20d420865b4d8e00a564396a6efbfea2109facd9R53-R58) [[3]](diffhunk://#diff-96ac15fded4bfe1d72c33acef6378e281bb40349ab16d173809d11aa55ea93b3R53-R58) [[4]](diffhunk://#diff-9c65bf1bcf0b5cc10af759ba2f024e17089c99a13173a16363c80be98d346d93R49-R54) [[5]](diffhunk://#diff-bc8c02f77f5960bac256a7403050f38bf06c2d17b1023cfde5fec17021556422R53-R58)
* Updated the corresponding `command.py` files to pass the `browser` argument to the viewer launch function, ensuring the selected mode is respected during execution. [[1]](diffhunk://#diff-5bc8b4ec232c7b5ff2aa3f27c877bdfc3d0575afb3d521aab742512e92911bf1R30) [[2]](diffhunk://#diff-951e5944015e11c7c1b448152336602675d9180d863cd93f3080af4503366648R30) [[3]](diffhunk://#diff-95d2b4e8fa0f01366acce226de332a0b4ede549f5f6967dfd2a7724c4731c721R30) [[4]](diffhunk://#diff-a5093827d0486a87c42434637b3d893d32308d45b55bd4f02cb4b3cc70b0c552R33) [[5]](diffhunk://#diff-ac53a6a078c53da505b263173e7be27fc91460952d769b54e84e35d7d492d670R30)

### Viewer launch logic

* Modified the `launch_viewer` and `DuckietownViewerInstance.start` methods in `utils/duckietown_viewer_utils.py` to accept and handle the `browser` argument, including opening the viewer URL in a web browser and waiting for user interruption. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL179-R183) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL205-R219)
* Imported the `webbrowser` module to support launching the viewer in browser mode.