### PR TITLE
Add Foxglove bridge to ROS2 stack

### DIFF
--- a/stack/stacks/ros2/duckiebot.yaml
+++ b/stack/stacks/ros2/duckiebot.yaml
@@ -167,6 +167,18 @@ services:
   #     # avahi socket
   #     - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
+  foxglove-bridge:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-foxglove-bridge
+    restart: unless-stopped
+    network_mode: host
+    command: ["bash", "-c", ". /opt/ros/jazzy/setup.bash && ros2 launch foxglove_bridge foxglove_bridge_launch.xml"]
+    environment:
+      ROS_DOMAIN_ID: 42
+      RMW_IMPLEMENTATION: rmw_zenoh_cpp
+    depends_on:
+      - zenoh-router
+
   car-interface:
     image: ${REGISTRY}/duckietown/dt-core:ente-${ARCH}
     container_name: car-interface


### PR DESCRIPTION
Introduce the Foxglove bridge service to the ROS2 stack, enabling enhanced communication and integration capabilities.