### PR TITLE
feat(run,sync): prevent remote permission flips - DTSW-7233

### DIFF
--- a/devel/run/command.py
+++ b/devel/run/command.py
@@ -264,15 +264,21 @@ class DTCommand(DTCommandAbs):
                         if not os.path.isdir(local_launch):
                             continue
 
-                        cc_mountpoints.append((local_launch, destination_launch, "rw"))
+                        # respect read-only setting for launcher mounts
+                        if parsed.read_only:
+                            cc_mountpoints.append((local_launch, destination_launch, "ro"))
+                        else:
+                            cc_mountpoints.append((local_launch, destination_launch, "rw"))
                         # make sure the launchers are executable (local only)
                         if local:
                             # noinspection PyBroadException
                             try:
                                 _run_cmd(["chmod", "a+x", os.path.join(local_launch, "*")], shell=True)
                             except Exception:
-                                dtslogger.warning("An error occurred while making the launchers executable. "
-                                                  "Things might not work as expected.")
+                                dtslogger.warning(
+                                    "An error occurred while making the launchers executable. "
+                                    "Things might not work as expected."
+                                )
 
                 # mount libraries explicitly to support symlinks (local only)
                 if not parsed.no_mount_libraries and local:
@@ -288,7 +294,10 @@ class DTCommand(DTCommandAbs):
                                 os.makedirs(local_mountpoint, exist_ok=True)
                                 real_local_lib = os.path.realpath(local_lib)
                                 destination_lib: str = os.path.join(destination_src, "libraries", f"__{lib_name}")
-                                cc_mountpoints.append((real_local_lib, destination_lib, "rw"))
+                                if parsed.read_only:
+                                    cc_mountpoints.append((real_local_lib, destination_lib, "ro"))
+                                else:
+                                    cc_mountpoints.append((real_local_lib, destination_lib, "rw"))
 
         # create image name
         cc_image = project.image(
@@ -434,6 +443,9 @@ class DTCommand(DTCommandAbs):
                 sync_args += ["-M"]
             elif isinstance(parsed.mount, str):
                 sync_args += ["-M", parsed.mount]
+            # propagate include-git for Mutagen
+            if getattr(parsed, "sync_include_git", False):
+                sync_args += ["--include-git"]
             # propagate optional flush direction
             if getattr(parsed, "sync_flush_direction", None):
                 sync_args += ["--flush-direction", parsed.sync_flush_direction]

--- a/devel/run/configuration.py
+++ b/devel/run/configuration.py
@@ -186,6 +186,13 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="After ensuring Mutagen sessions, perform a one-shot flush in this direction",
         )
         parser.add_argument(
+            "--sync-include-git",
+            dest="sync_include_git",
+            default=False,
+            action="store_true",
+            help="Include the .git directory in remote sync",
+        )
+        parser.add_argument(
             "--net",
             "--network_mode",
             dest="network_mode",
@@ -206,6 +213,7 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=None,
             help="Overrides 'version' (usually taken to be branch name)"
         )
+        # Mount mode: read-only available, but default remains read-write
         parser.add_argument(
             "-RO",
             "--read-only",
@@ -213,6 +221,13 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Mount the project in read-only mode",
+        )
+        parser.add_argument(
+            "--read-write",
+            "--rw",
+            dest="read_only",
+            action="store_false",
+            help="Mount the project in read-write mode",
         )
         parser.add_argument("docker_args", nargs="*", default=[])
         # ---

--- a/devel/sync/command.py
+++ b/devel/sync/command.py
@@ -15,7 +15,7 @@ from devel.run.command import REMOTE_USER as DEFAULT_REMOTE_USER
 # Default host path on the robot to mirror code into (bind-mount this in containers)
 REMOTE_SYNC_CODE_LOCATION = "/code"
 
-# Default ignore patterns for sync
+# Default ignore patterns for sync (by default .git is ignored; can be included via --include-git)
 DEFAULT_IGNORE: List[str] = [
     ".git/",
     ".cache/",
@@ -115,10 +115,14 @@ class DTCommand(DTCommandAbs):
             beta = f"ssh://{DEFAULT_REMOTE_USER}@{parsed.machine}//{remote_host_dir.lstrip('/')}"
             try:
                 sync = MutagenSync(name=session_name)
+                # Determine ignore paths (optionally include .git)
+                ignore_paths = list(DEFAULT_IGNORE)
+                if getattr(parsed, "include_git", False):
+                    ignore_paths = [p for p in ignore_paths if p != ".git/"]
                 session = sync.ensure_session(
                     alpha=alpha,
                     beta=beta,
-                    ignore_paths=DEFAULT_IGNORE,
+                    ignore_paths=ignore_paths,
                     max_staging_file_size="64MiB",
                 )
                 dtslogger.info(f"Session ready: {session.name} ({session.identifier})")

--- a/devel/sync/configuration.py
+++ b/devel/sync/configuration.py
@@ -48,5 +48,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             choices=("alpha-to-beta", "beta-to-alpha"),
             help="After ensuring sessions, perform a one-shot flush in this direction",
         )
+        parser.add_argument(
+            "--include-git",
+            dest="include_git",
+            default=False,
+            action="store_true",
+            help="Include the .git directory in the sync",
+        )
         # ---
         return parser

--- a/utils/mutagen_sync.py
+++ b/utils/mutagen_sync.py
@@ -180,6 +180,8 @@ class MutagenSync:
         symlink_mode: str = "portable",
         mode: str = "two-way-resolved",
         max_staging_file_size: Optional[str] = None,  # e.g., "128MiB"
+        # Permission handling: avoid propagating permission changes cross-endpoint
+        permissions: Optional[str] = "manual",  # try to disable permission syncing; fallback if unsupported
     ) -> MutagenSession:
         """
         Create the session if it doesn't exist; otherwise reuse it.
@@ -202,6 +204,8 @@ class MutagenSync:
         # Optional flags that might be unsupported in older Mutagen versions
         mode_flag = f"--mode={mode}" if mode else None
         max_stage_flag = f"--max-staging-file-size={max_staging_file_size}" if max_staging_file_size else None
+        # Attempt to configure permissions in a way that avoids permission flips
+        permissions_flag = f"--permissions={permissions}" if permissions else None
         if ignore_paths:
             # Mutagen supports multiple --ignore options
             for p in ignore_paths:
@@ -212,12 +216,15 @@ class MutagenSync:
         last_error: Optional[Exception] = None
         use_mode = bool(mode_flag)
         use_max_stage = bool(max_stage_flag)
+        use_permissions = bool(permissions_flag)
         for cand_beta in candidate_betas:
             args = list(base_args)
             if use_mode and mode_flag:
                 args.append(mode_flag)
             if use_max_stage and max_stage_flag:
                 args.append(max_stage_flag)
+            if use_permissions and permissions_flag:
+                args.append(permissions_flag)
             args += [alpha, cand_beta]
 
             # Attempt creation with current flags
@@ -239,6 +246,12 @@ class MutagenSync:
                         use_max_stage = False
                         args = [a for a in args if not a.startswith("--max-staging-file-size=")]
                         continue
+                    if use_permissions and ("unknown flag" in msg or "flag provided but not defined" in msg) and "--permissions" in " ".join(args):
+                        # Remove --permissions and retry
+                        use_permissions = False
+                        args = [a for a in args if not a.startswith("--permissions=")]
+                        continue
+                    # default file/dir mode flags removed by design
                     # Endpoint style issue: try next candidate
                     if "could not resolve hostname ssh" in msg or "unable to dial agent endpoint" in msg:
                         last_error = e


### PR DESCRIPTION
- Mutagen sessions use --permissions=manual to keep remote chmod from propagating to local
- Remove default file/dir mode flags to avoid enforcing modes
- Add dts devel sync --include-git and forward via dts devel run --sync-include-git
- Keep launcher chmod and honor --read-only mounts
