### PR TITLE
fix: add --privileged flag to docker args for improved container permissions

### DIFF
--- a/code/workbench/command.py
+++ b/code/workbench/command.py
@@ -107,7 +107,7 @@ class DTCommand(DTCommandAbs):
                 return False
 
         # docker args
-        docker_args: List[str] = []
+        docker_args: List[str] = ["--privileged"]
         # - ros master uri
         docker_args.extend(["-e", f"ROS_MASTER_URI=http://{parsed.robot}.local:11311/"])
 


### PR DESCRIPTION
This pull request makes a small update to the default Docker arguments used when running commands in the `code/workbench/command.py` file. The change ensures that Docker containers are started with the `--privileged` flag by default, which can be necessary for certain operations that require extended privileges.