### PR TITLE
feat: add certificate verification after creation to ensure validity of domain certificate

### DIFF
--- a/setup/mkcert/command.py
+++ b/setup/mkcert/command.py
@@ -167,7 +167,7 @@ class DTCommand(DTCommandAbs):
         DTCommand.verify_certificate_validity(ssl_cert, ca_cert)
         
 
-    def verify_certificate_validity(domain_certificate_path: Path, ca_cert_path: Path):
+    def verify_certificate_validity(domain_certificate_path: str, ca_cert_path: str):
         """Verify that the domain certificate is valid against the local Certificate Authority."""
         dtslogger.info("Verifying the domain certificate...")
         cmd_verify: List[str] = [

--- a/setup/mkcert/command.py
+++ b/setup/mkcert/command.py
@@ -167,6 +167,7 @@ class DTCommand(DTCommandAbs):
         DTCommand.verify_certificate_validity(ssl_cert, ca_cert)
         
 
+    @staticmethod
     def verify_certificate_validity(domain_certificate_path: str, ca_cert_path: str):
         """Verify that the domain certificate is valid against the local Certificate Authority."""
         dtslogger.info("Verifying the domain certificate...")

--- a/setup/mkcert/command.py
+++ b/setup/mkcert/command.py
@@ -178,7 +178,7 @@ class DTCommand(DTCommandAbs):
             ca_cert_path,
             domain_certificate_path,
         ]
-        dtslogger.debug(f"Running command:\n\t$ {cmd_verify}\n")
+        dtslogger.debug(f"Running command:\n\t$ {' '.join(str(x) for x in cmd_verify)}\n")
         try:
             out_verify = subprocess.check_output(cmd_verify, stderr=STDOUT).decode("utf-8")
         except subprocess.CalledProcessError as e:

--- a/setup/mkcert/command.py
+++ b/setup/mkcert/command.py
@@ -162,6 +162,36 @@ class DTCommand(DTCommandAbs):
             dtslogger.info(f"A new certificate for the domain '{LOCAL_DOMAIN}' was created.")
         else:
             dtslogger.info(f"Existing domain certificate found in [{ssl_dir}]")
+            
+        # verify certificates
+        DTCommand.verify_certificate_validity(ssl_cert, ca_cert)
+        
+
+    def verify_certificate_validity(domain_certificate_path: Path, ca_cert_path: Path):
+        """Verify that the domain certificate is valid against the local Certificate Authority."""
+        dtslogger.info("Verifying the domain certificate...")
+        cmd_verify: List[str] = [
+            "openssl",
+            "verify",
+            "-CAfile",
+            ca_cert_path,
+            domain_certificate_path,
+        ]
+        dtslogger.debug(f"Running command:\n\t$ {cmd_verify}\n")
+        try:
+            out_verify = subprocess.check_output(cmd_verify, stderr=STDOUT).decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            dtslogger.error(f"Command {' '.join(cmd_verify)} failed with exit code {e.returncode}:\n{e.output.decode('utf-8')}")
+            raise
+        dtslogger.info(f"Certificate verification result: {out_verify.strip()}")
+        if "OK" not in out_verify:
+            raise Exception("The domain certificate is not valid.")
+        
+        dtslogger.info(f"Domain certificate is valid against CA at {ca_cert_path}!")
+        dtslogger.info(
+            "If using a devcontainer, ensure the root CA is also installed in the host "
+            "system's trust store by running 'mkcert -install' on your host machine."
+        )
 
     @staticmethod
     def _get_mkcert_bin_url() -> str:


### PR DESCRIPTION
This pull request adds a certificate verification step to the `setup/mkcert/command.py` script to ensure that domain certificates are valid against the local Certificate Authority (CA). This helps improve security and reliability by catching invalid certificates early in the setup process.

**Certificate Verification Enhancements:**

* Added a new method `verify_certificate_validity` to check that the domain certificate is valid against the CA using the `openssl verify` command. If verification fails, an exception is raised and the error is logged.
* Integrated the certificate verification step into the main command flow, so certificates are always checked after generation or detection.
* Improved logging to provide clear feedback on certificate verification results and next steps for users working in devcontainers.

## Testing
To test this you need to:

1. Stop the devcontainer by quitting VSCode.
2. Delete the devcontainer's volume in orbstack
<img width="1336" height="762" alt="Screenshot 2025-11-03 at 17 41 03" src="https://github.com/user-attachments/assets/50e5ab1c-9389-4970-8ee7-f4851780f151" />

4. Rebuild and reopen the devcontainer
5. Proceed with the configuration using the instructions available on the [Duckumentation here](https://docs.duckietown.com/ente/duckietown-manual/10-setup/setup-devcontainer.html?highlight=devcontainer)
6. Run the `lx-ros-basic` (or any other lx) according to the instructions. Specifically you will want to test that when running `dts code editor` you are able to access the VSCode browser instance that opens.