### PR TITLE
DTSW-7392-Create-WebGL-version

### DIFF
--- a/matrix/devel/release/command.py
+++ b/matrix/devel/release/command.py
@@ -81,7 +81,9 @@ class DTCommand(DTCommandAbs):
         with open(json_fp, "rt") as fin:
             meta = json.loads(fin.read())
         release_version = meta["version"]
-        os_family = meta["target"]["operating_system_family"].lower()
+        if os_family.lower() != "webgl":
+            os_family = meta["target"]["operating_system_family"].lower()
+        release = release_version + "-" + os_family
 
         # make sure we have a token
         token: str = parsed.token
@@ -90,7 +92,7 @@ class DTCommand(DTCommandAbs):
 
         # check whether the same version was already released
         if is_version_released(release_version, os_family):
-            dtslogger.warn(f"The version v{release_version} for OS Family '{os_family}' was found "
+            dtslogger.warn(f"The version v{release} was found "
                            f"already on the DCSS, are you re-releasing this version? "
                            f"(use -f/--force to continue)")
             if not parsed.force:
@@ -99,8 +101,9 @@ class DTCommand(DTCommandAbs):
                 dtslogger.warn("Forced!")
 
         # check whether we are releasing an older version
-        latest = get_latest_version(os_family)
-        if versiontuple(latest) > versiontuple(release_version):
+        latest_version = get_latest_version(os_family)
+        latest = latest_version + "-" + os_family
+        if versiontuple(latest_version) > versiontuple(release_version):
             dtslogger.warn(f"The version v{latest} was found on the DCSS, are you releasing "
                            f"an older version? (use -f/--force to continue)")
             if not parsed.force:
@@ -109,7 +112,7 @@ class DTCommand(DTCommandAbs):
                 dtslogger.warn("Forced!")
 
         # upload
-        dtslogger.info(f"Uploading version v{release_version}...")
+        dtslogger.info(f"Uploading version v{release}...")
         zip_remote = remote_zip_obj(release_version, os_family)
         shell.include.data.push.command(
             shell,
@@ -126,10 +129,10 @@ class DTCommand(DTCommandAbs):
         )
 
         # mark this as latest (if needed)
-        if versiontuple(latest) < versiontuple(release_version):
+        if versiontuple(latest_version) < versiontuple(release_version):
             mark_as_latest_version(token, release_version, os_family)
 
-        dtslogger.info(f"Congrats! You just released version v{release_version}.")
+        dtslogger.info(f"Congrats! You just released version v{release}.")
 
     @staticmethod
     def complete(shell, word, line):

--- a/matrix/info/command.py
+++ b/matrix/info/command.py
@@ -6,7 +6,8 @@ from dt_shell import DTCommandAbs, dtslogger, DTShell
 from utils.duckiematrix_utils import \
     APP_NAME, \
     get_most_recent_version_installed, \
-    get_path_to_install
+    get_path_to_install, \
+    get_os_family
 
 
 class DTCommand(DTCommandAbs):
@@ -24,6 +25,12 @@ class DTCommand(DTCommandAbs):
             type=str,
             help="Show info about a specific version"
         )
+        parser.add_argument(
+            "--webgl",
+            default=False,
+            action="store_true",
+            help="Show info about the WebGL version"
+        )
         parsed, _ = parser.parse_known_args(args=args)
         return parsed
 
@@ -33,7 +40,8 @@ class DTCommand(DTCommandAbs):
         if parsed is None:
             parsed = DTCommand._parse_args(args)
         # ---
-        version = parsed.version if parsed.version else get_most_recent_version_installed()
+        os_family = "webgl" if parsed.webgl else get_os_family()
+        version = parsed.version if parsed.version else get_most_recent_version_installed(os_family)
         if version is None:
             dtslogger.error(
                 f"Version v{parsed.version} not found."
@@ -42,7 +50,8 @@ class DTCommand(DTCommandAbs):
             return
         # ---
         install_dir = get_path_to_install(version)
-        meta_fp = os.path.join(install_dir, f"{APP_NAME}.json")
+        capitalized_app_name = APP_NAME.capitalize()
+        meta_fp = os.path.join(install_dir, f"{capitalized_app_name}.json")
         with open(meta_fp, 'rt') as fin:
             meta = json.load(fin)
         # ---

--- a/matrix/install/command.py
+++ b/matrix/install/command.py
@@ -12,7 +12,8 @@ from utils.duckiematrix_utils import \
     APP_RELEASES_DIR, \
     get_most_recent_version_installed, \
     remote_zip_obj, \
-    get_latest_version
+    get_latest_version, \
+    get_os_family
 
 from utils.misc_utils import versiontuple
 
@@ -28,23 +29,29 @@ class DTCommand(DTCommandAbs):
         parser.add_argument(
             "-U",
             "--update",
-            default=None,
+            default=False,
             action="store_true",
             help="Update if already installed",
         )
         parser.add_argument(
             "-f",
             "--force",
-            default=None,
+            default=False,
             action="store_true",
             help="Force reinstall when the same version is already installed",
         )
         parser.add_argument(
             "-v",
             "--version",
-            default=None,
+            default="",
             type=str,
             help="Install a specific version"
+        )
+        parser.add_argument(
+            "--webgl",
+            default=False,
+            action="store_true",
+            help="Install the WebGL version"
         )
         parsed, _ = parser.parse_known_args(args=args)
         return parsed
@@ -59,14 +66,16 @@ class DTCommand(DTCommandAbs):
             dtslogger.error(f"You need to have the library dt-data-api>=1.0.1, "
                             f"the version {dt_data_api.__version__} was found instead.")
             return
+        os_family = "webgl" if parsed.webgl else get_os_family()
         # make sure the app is not already installed
-        installed_version = get_most_recent_version_installed()
+        installed_version = get_most_recent_version_installed(os_family)
         if installed_version is not None and not parsed.update:
             dtslogger.info(f"Found version 'v{installed_version}' already installed. \nUse "
                            f"-U/--update to update to the latest version (if any is available).")
             return
         # get latest version available on the DCSS
-        latest = get_latest_version()
+        latest_version = get_latest_version(os_family)
+        latest = latest_version + "-" + os_family
         # compare installed and latest versions
         if installed_version:
             if installed_version == latest:
@@ -85,7 +94,7 @@ class DTCommand(DTCommandAbs):
         # download
         dtslogger.info(f"Downloading version v{latest}...")
         os.makedirs(app_dir)
-        zip_remote = remote_zip_obj(latest)
+        zip_remote = remote_zip_obj(latest_version, os_family)
         zip_local = os.path.join(app_dir, f"v{latest}.zip")
         shell.include.data.get.command(
             shell,

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -1,9 +1,15 @@
+import os
 import time
 from pathlib import Path
 
 import argparse
 import subprocess
 import platform
+import socket
+import webbrowser
+from socket import AF_INET, SOCK_STREAM
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Thread
 from typing import Optional, Callable
 
 from dt_shell import DTCommandAbs, dtslogger, DTShell
@@ -11,7 +17,9 @@ from ..engine.run.command import MatrixEngine
 from utils.duckiematrix_utils import \
     APP_NAME, \
     get_most_recent_version_installed, \
-    get_path_to_binary
+    get_path_to_binary, \
+    get_path_to_install, \
+    get_os_family
 
 EXTERNAL_SHUTDOWN_REQUEST: str = "===REQUESTED-EXTERNAL-SHUTDOWN==="
 IS_MACOS: bool = platform.system() == "Darwin"
@@ -156,6 +164,24 @@ class DTCommand(DTCommandAbs):
             action="store_true",
             help="Enable the profiler (requires -S/--standalone)"
         )
+        parser.add_argument(
+            "--browser",
+            default=False,
+            action="store_true",
+            help="Run in browser mode"
+        )
+        parser.add_argument(
+            "--host",
+            default="localhost",
+            type=str,
+            help="Hostname or IP address to bind the HTTP server"
+        )
+        parser.add_argument(
+            "--port",
+            default=None,
+            type=int,
+            help="Port number to bind the HTTP server"
+        )
         parsed, _ = parser.parse_known_args(args=args)
         return parsed
 
@@ -216,8 +242,14 @@ class DTCommand(DTCommandAbs):
             if parsed.version:
                 version = parsed.version
             else:
-                shell.include.matrix.install.command(shell, ["--update"])
-                version = get_most_recent_version_installed()
+                args = ["--update"]
+                if parsed.browser:
+                    args.append("--webgl")
+                    os_family = "webgl"
+                else:
+                    os_family = get_os_family()
+                shell.include.matrix.install.command(shell, args)
+                version = get_most_recent_version_installed(os_family)
             dtslogger.info(f"Configuring Renderer ({version})...")
             dtslogger.debug(f"Will try to run {version}...")
             # make sure the app is installed
@@ -286,8 +318,43 @@ class DTCommand(DTCommandAbs):
                         engine.stop()
                         return
 
-                # on MacOS, we open the location of the app
-                if IS_MACOS:
+                if parsed.browser:
+                    dtslogger.info("Launching Renderer in browser...")
+                    app_dir = get_path_to_install(version)
+                    app_path = os.path.join(app_dir, "duckiematrix")
+                    os.chdir(app_path)
+                    host = parsed.host
+                    port = parsed.port
+                    if port is None:
+                        with socket.socket(AF_INET, SOCK_STREAM) as socket_:
+                            socket_.bind((host, 0))
+                            socket_.listen(1)
+                            sock_name = socket_.getsockname()
+                            port = sock_name[1]
+                    server = HTTPServer((host, port), SimpleHTTPRequestHandler)
+                    server_thread = Thread(target=server.serve_forever)
+                    server_thread.daemon = True
+                    url = f"http://{host}:{port}/?"
+                    if parsed.renderer_id is not None:
+                        url += f"renderer-id={parsed.renderer_id}&"
+                    if parsed.renderer_key is not None:
+                        url += f"renderer-key={parsed.renderer_key}&"
+                    if parsed.engine_hostname is not None:
+                        url += f"engine-hostname={parsed.engine_hostname}&"
+                    url += f"profiler={'true' if parsed.profiler else 'false'}&"
+                    url += f"tutorial={'true' if not parsed.no_tutorial else 'false'}&"
+                    url += f"token={shell.profile.secrets.dt_token}/"
+                    server_thread.start()
+                    if not webbrowser.open(url):
+                        dtslogger.warning("Could not open browser.")
+                    dtslogger.info(f"Navigate to {url}.")
+                    # wait for the engine to terminate
+                    if run_engine:
+                        engine.join()
+                    else:
+                        server_thread.join()
+                elif IS_MACOS:
+                    # on MacOS, we open the location of the app
                     app_location: str = str(Path(app_bin).parent)
                     dtslogger.info(f"\n===================\n"
                                    f"  The Duckiematrix app is located at:\n\n\t{app_location}/\n\n"

--- a/utils/duckiematrix_utils.py
+++ b/utils/duckiematrix_utils.py
@@ -27,20 +27,19 @@ def get_os_family() -> str:
         return "macosx"
 
 
-def get_latest_version(os_family: str = None):
+def get_latest_version(os_family: str = ""):
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
     # get latest version
-    os_family = os_family or get_os_family()
     latest_version_obj = os.path.join(DCSS_APP_DIR, f"latest-{os_family}")
     download = storage.download(latest_version_obj)
     download.join()
     return download.data.decode("ascii").strip()
 
 
-def get_all_installed_releases() -> List[str]:
-    app_dir = os.path.join(APP_RELEASES_DIR, "*")
+def get_all_installed_releases(os_family: str = "") -> List[str]:
+    app_dir = os.path.join(APP_RELEASES_DIR, f"*-{os_family}")
     dirs = glob.glob(app_dir)
     version_regex = r"v([0-9]+)\.([0-9]+)\.([0-9]+)"
     version_pattern = re.compile(version_regex)
@@ -48,8 +47,8 @@ def get_all_installed_releases() -> List[str]:
     return list(map(lambda p: os.path.basename(p)[1:], filter(is_release_dir, dirs)))
 
 
-def get_most_recent_version_installed() -> Optional[str]:
-    releases = get_all_installed_releases()
+def get_most_recent_version_installed(os_family: str = "") -> Optional[str]:
+    releases = get_all_installed_releases(os_family)
     release = None
     for r in releases:
         if release is None or versiontuple(r) > versiontuple(release):
@@ -82,7 +81,7 @@ def get_path_to_binary(version: str):
     return os.path.join(app_dir, f"{APP_NAME}.{ext}")
 
 
-def is_version_released(version: str, os_family: str = None) -> bool:
+def is_version_released(version: str, os_family: str = "") -> bool:
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
@@ -95,8 +94,7 @@ def is_version_released(version: str, os_family: str = None) -> bool:
         return False
 
 
-def remote_zip_obj(version: str, os_family: str = None):
-    os_family = os_family or get_os_family()
+def remote_zip_obj(version: str, os_family: str = "") -> str:
     return os.path.join(DCSS_APP_RELEASES_DIR, f"{APP_NAME}-{version}-{os_family}.zip")
 
 


### PR DESCRIPTION
This pull request introduces support for managing and running the Duckiematrix application in "WebGL" mode, alongside improvements to version handling and command-line argument parsing. The changes ensure that commands can target both standard and WebGL builds, streamline version management per operating system family, and add browser-based launching capabilities.

**WebGL Mode Support**

* Added `--webgl` argument to `install`, `info`, and `run` commands, allowing users to install, query, and run the WebGL version of Duckiematrix. The code now determines the operating system family dynamically and passes it to relevant utility functions. [[1]](diffhunk://#diff-c4f82bb34a181f97f52c2ee3accc0362568ad1fd181c9dddc9b5d82144141e65R28-R33) [[2]](diffhunk://#diff-eb642d143aa72bd6e0aa5fdb707928d07a397f135ae97263d1c596d773f3dc93L31-R55) [[3]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR167-R184)
* Utility functions such as `get_latest_version`, `get_all_installed_releases`, and `get_most_recent_version_installed` now accept an `os_family` parameter, enabling version management per OS family (including "webgl").

**Browser Launching Functionality**

* Added `--browser`, `--host`, and `--port` arguments to the `run` command. When `--browser` is specified, the app launches a local HTTP server and opens the Duckiematrix WebGL build in the user's browser, passing relevant parameters via the URL. [[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR167-R184) [[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR321-L290)

**Version and Release Handling Improvements**

* Version strings are now consistently suffixed with the OS family (e.g., `v1.2.3-webgl`), and all logging and release checks use this format. This prevents confusion between releases for different platforms. [[1]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427R84-R86) [[2]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L93-R95) [[3]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L102-R106) [[4]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L112-R115) [[5]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L129-R135) [[6]](diffhunk://#diff-eb642d143aa72bd6e0aa5fdb707928d07a397f135ae97263d1c596d773f3dc93R69-R78) [[7]](diffhunk://#diff-eb642d143aa72bd6e0aa5fdb707928d07a397f135ae97263d1c596d773f3dc93L88-R97)

**Command-Line Argument Parsing Consistency**

* Changed default values for several arguments (`--update`, `--force`, `--version`) to ensure consistent behavior and easier handling of flags.

**File Handling and Metadata Improvements**

* Fixed metadata file lookup to use a capitalized app name, improving cross-platform compatibility.

Let me know if you'd like more details about any specific change!