### PR TITLE
feat: add ROS 2 Duckiedrone stack configuration

### DIFF
--- a/stack/stacks/ros2/duckiedrone.yaml
+++ b/stack/stacks/ros2/duckiedrone.yaml
@@ -1,0 +1,83 @@
+services:
+
+  zenoh-router:
+    image: ${REGISTRY}/duckietown/dt-ros2-commons:ente-${ARCH}
+    container_name: zenoh-router
+    command: ["bash", "-c", ". /opt/ros/jazzy/setup.bash && ros2 run rmw_zenoh_cpp rmw_zenohd"]
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      ZENOH_ROUTER_ID: duckiedrone_router
+      ROS_DOMAIN_ID: 42
+
+  camera:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-camera
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-camera
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
+  tof:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-tof
+    restart: unless-stopped
+    network_mode: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-tof
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
+  mavros:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-mavros
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: mavros
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+      - /data:/data
+    depends_on:
+      - zenoh-router
+
+  foxglove-bridge:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-foxglove-bridge
+    restart: unless-stopped
+    network_mode: host
+    command: ["bash", "-c", ". /opt/ros/jazzy/setup.bash && ros2 launch foxglove_bridge foxglove_bridge_launch.xml"]
+    environment:
+      ROS_DOMAIN_ID: 42
+      RMW_IMPLEMENTATION: rmw_zenoh_cpp
+    depends_on:
+      - zenoh-router
+
+  # Functionalities nodes
+  


### PR DESCRIPTION
Adding the ROS2 stack for the Duckiedrone.
Currently only the mavros node is functional, there are bugs to be fixed in the camera and tof nodes.