### PR TITLE
DTSW-7540-Resolve-Docker-API-version-mismatch-for-Duckietown-projects

### DIFF
--- a/devel/run/command.py
+++ b/devel/run/command.py
@@ -555,8 +555,10 @@ def _run_cmd(
     if shell and isinstance(cmd, (list, tuple)):
         cmd = " ".join([str(s) for s in cmd])
     dtslogger.debug("$ %s" % cmd)
+    env = os.environ.copy()
+    env["DOCKER_API_VERSION"] = "1.41"
     if get_output:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=shell)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=shell, env=env)
         proc.wait()
         if proc.returncode != 0:
             if not suppress_errors:
@@ -569,11 +571,11 @@ def _run_cmd(
         return out
     else:
         if return_exitcode:
-            res = subprocess.run(cmd, shell=shell)
+            res = subprocess.run(cmd, shell=shell, env=env)
             return res.returncode
         else:
             try:
-                subprocess.check_call(cmd, shell=shell)
+                subprocess.check_call(cmd, shell=shell, env=env)
             except subprocess.CalledProcessError as e:
                 if not suppress_errors:
                     raise e


### PR DESCRIPTION
This pull request updates the environment handling for subprocess calls in the `_run_cmd` function within `devel/run/command.py`. The most significant change is the explicit setting of the `DOCKER_API_VERSION` environment variable for all subprocesses, which ensures compatibility with Docker commands.

**Environment variable management:**

* All subprocess calls in `_run_cmd` now use a copied environment with `DOCKER_API_VERSION` set to `"1.41"`, ensuring consistent Docker API behavior. [[1]](diffhunk://#diff-134afde4b85ee842773577a6a4deb1462b2d87115d4612869042c59de5a50224R558-R561) [[2]](diffhunk://#diff-134afde4b85ee842773577a6a4deb1462b2d87115d4612869042c59de5a50224L572-R578)

**Subprocess invocation updates:**

* The `env` parameter is now passed to all `subprocess.Popen`, `subprocess.run`, and `subprocess.check_call` invocations, ensuring the environment variable is set for every command execution. [[1]](diffhunk://#diff-134afde4b85ee842773577a6a4deb1462b2d87115d4612869042c59de5a50224R558-R561) [[2]](diffhunk://#diff-134afde4b85ee842773577a6a4deb1462b2d87115d4612869042c59de5a50224L572-R578)