### PR TITLE
DTSW-7566-dts-matrix-run-not-working-on-arm-macs

### DIFF
--- a/__command_set__/requirements.txt
+++ b/__command_set__/requirements.txt
@@ -1,14 +1,15 @@
 # generic dependencies
 netifaces-plus==0.12.*
 docker==6.1.3
-docker-compose==1.29.2
+# docker-compose package removed - codebase uses 'docker compose' CLI (v2), not the Python library
 GitPython==3.1.37
 python-dateutil==2.8.2
 pytz==2023.3
 psutil>=5.9.0 # FIXME: this had to be pinned to get the dependencies to resolve on aarch64
 
 # force pyyaml away from specific versions: https://github.com/yaml/pyyaml/issues/724
-pyyaml!=6.0.0,!=5.4.0,!=5.4.1,<7
+# Use 6.0.1+ for pre-built wheels on macOS ARM (Python 3.12+)
+pyyaml>=6.0.1,<7
 zeroconf==0.122.0
 
 # duckietown dependencies


### PR DESCRIPTION
This pull request updates the Python dependencies in `__command_set__/requirements.txt` to better align with the project's current tooling and platform support. The most notable changes are the removal of an unused dependency and an update to improve compatibility with newer hardware and Python versions.

Dependency management improvements:

* Removed the `docker-compose` Python package, as the codebase now relies on the `docker compose` CLI (v2) instead of the Python library.
* Updated the `pyyaml` dependency to require version 6.0.1 or newer (but still less than 7), ensuring pre-built wheels are available for macOS ARM (Python 3.12+), which improves installation reliability on newer hardware.