### PR TITLE
DTSW-7564-Add-Duckietown-Shell-billboards-to-the-Duckiematrix

### DIFF
--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -1,5 +1,7 @@
+import json
 import os
 import time
+from collections import Counter
 from pathlib import Path
 
 import argparse
@@ -13,6 +15,8 @@ from threading import Thread
 from typing import Optional, Callable
 
 from dt_shell import DTCommandAbs, dtslogger, DTShell
+from dt_shell.constants import DB_BILLBOARDS
+from dt_shell.database import DTShellDatabase
 from ..engine.run.command import MatrixEngine
 from utils.duckiematrix_utils import \
     APP_NAME, \
@@ -308,6 +312,18 @@ class DTCommand(DTCommandAbs):
                 app_config += ["--profiler"]
             # token
             app_config += ["--token", shell.profile.secrets.dt_token]
+            # billboards
+            billboards_database = DTShellDatabase.open(DB_BILLBOARDS)
+            billboard_names = shell.get_billboard_names(billboards_database)
+            if billboard_names:
+                billboard = shell.get_billboard(billboards_database, billboard_names)
+                if billboard:
+                    app_config += ["--billboard", billboard]
+                app_config += ["--billboards-path", billboards_database.yaml]
+                # convert list with repeated names to JSON with frequencies
+                counter = Counter(billboard_names)
+                billboard_names_dict = dict(counter)
+                app_config += ["--billboard-names", json.dumps(billboard_names_dict)]
             # ---
             dtslogger.info("Renderer configured!")
             # RENDERER is now configured


### PR DESCRIPTION
This pull request enhances the `matrix/run/command.py` script by adding support for handling "billboards" through integration with the DTShell database. The main changes involve fetching billboard information, passing relevant configuration to the application, and serializing billboard name frequencies as JSON.

Billboard integration:

* Added imports for `DB_BILLBOARDS` and `DTShellDatabase` to enable access to the billboards database.
* Opened the billboards database, retrieved billboard names, and selected a billboard using shell helper methods. If available, the selected billboard and the path to the billboards database YAML file are added to the app configuration.
* Counted occurrences of billboard names using `Counter`, converted the result to a dictionary, and added it as a JSON string to the application configuration via the `--billboard-names` argument. [[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR1-R4) [[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR315-R326)

Dependency updates:

* Imported `json` and `Counter` to support serialization and frequency counting for billboard names.