### PR TITLE
DTSW-7572-Address-Duckietown-Shell-syntax-warnings

### DIFF
--- a/init_sd_card/constants.py
+++ b/init_sd_card/constants.py
@@ -28,7 +28,7 @@ You can use --no-steps to exclude some steps:
 
 """
 
-LIST_DEVICES_CMD = "lsblk -p --output NAME,TYPE,SIZE,VENDOR | grep --color=never 'disk\|TYPE'"
+LIST_DEVICES_CMD = r"lsblk -p --output NAME,TYPE,SIZE,VENDOR | grep --color=never 'disk\|TYPE'"
 
 
 WPA_OPEN_NETWORK_CONFIG = """

--- a/utils/template_utils.py
+++ b/utils/template_utils.py
@@ -39,7 +39,7 @@ class SafeDTTemplate(Template):
                 """
 
     def substitute(self, *args, **kws):
-        if all([re.match("[^A-Z\s]*$", repl) for repl in list(kws.values())]):
+        if all([re.match(r"[^A-Z\s]*$", repl) for repl in list(kws.values())]):
             return super(SafeDTTemplate, self).substitute(*args, **kws)
         else:
             raise InvalidUserInput("The input value does not follow the safe path format: `this_1-is-safe`")


### PR DESCRIPTION
This pull request makes minor improvements to string handling by consistently using raw string literals for regular expressions and shell commands. This change helps prevent issues with escape characters and improves code readability.

- String handling improvements:
  * Changed the `LIST_DEVICES_CMD` definition in `constants.py` to use a raw string literal for the shell command.
  * Updated the regular expression in the `SafeDTTemplate.substitute` method in `template_utils.py` to use a raw string literal, ensuring correct interpretation of escape sequences.