### PR TITLE
DTSW-7594-Add-the-ability-to-release-and-install-a-specific-version-of-the-Duckiematrix-Renderer-to-the-Duckietown-Shell

### DIFF
--- a/matrix/devel/release/command.py
+++ b/matrix/devel/release/command.py
@@ -46,6 +46,13 @@ class DTCommand(DTCommandAbs):
             default=None,
             help="(Optional) Duckietown token to use for the upload action",
         )
+        parser.add_argument(
+            "-v",
+            "--version",
+            default=None,
+            type=str,
+            help="Release a specific version",
+        )
         parsed, _ = parser.parse_known_args(args=args)
         return parsed
 
@@ -80,7 +87,8 @@ class DTCommand(DTCommandAbs):
         # load metadata
         with open(json_fp, "rt") as fin:
             meta = json.loads(fin.read())
-        release_version = meta["version"]
+        version = parsed.version
+        release_version = version if version else meta["version"]
         if os_family.lower() != "webgl":
             os_family = meta["target"]["operating_system_family"].lower()
         release = release_version + "-" + os_family
@@ -90,26 +98,27 @@ class DTCommand(DTCommandAbs):
         if token is None:
             token = shell.profile.secrets.dt_token
 
-        # check whether the same version was already released
-        if is_version_released(release_version, os_family):
-            dtslogger.warn(f"The version v{release} was found "
-                           f"already on the DCSS, are you re-releasing this version? "
-                           f"(use -f/--force to continue)")
-            if not parsed.force:
-                return
-            else:
-                dtslogger.warn("Forced!")
+        if not version:
+            # check whether the same version was already released
+            if is_version_released(release_version, os_family):
+                dtslogger.warn(f"The version v{release} was found "
+                            f"already on the DCSS, are you re-releasing this version? "
+                            f"(use -f/--force to continue)")
+                if not parsed.force:
+                    return
+                else:
+                    dtslogger.warn("Forced!")
 
-        # check whether we are releasing an older version
-        latest_version = get_latest_version(os_family)
-        latest = latest_version + "-" + os_family
-        if versiontuple(latest_version) > versiontuple(release_version):
-            dtslogger.warn(f"The version v{latest} was found on the DCSS, are you releasing "
-                           f"an older version? (use -f/--force to continue)")
-            if not parsed.force:
-                return
-            else:
-                dtslogger.warn("Forced!")
+            # check whether we are releasing an older version
+            latest_version = get_latest_version(os_family)
+            latest = latest_version + "-" + os_family
+            if versiontuple(latest_version) > versiontuple(release_version):
+                dtslogger.warn(f"The version v{latest} was found on the DCSS, are you releasing "
+                            f"an older version? (use -f/--force to continue)")
+                if not parsed.force:
+                    return
+                else:
+                    dtslogger.warn("Forced!")
 
         # upload
         dtslogger.info(f"Uploading version v{release}...")
@@ -129,10 +138,10 @@ class DTCommand(DTCommandAbs):
                 compress=True
             )
         )
-
-        # mark this as latest (if needed)
-        if versiontuple(latest_version) < versiontuple(release_version):
-            mark_as_latest_version(token, release_version, os_family)
+        if not version:
+            # mark this as latest (if needed)
+            if versiontuple(latest_version) < versiontuple(release_version):
+                mark_as_latest_version(token, release_version, os_family)
 
         dtslogger.info(f"Congrats! You just released version v{release}.")
 

--- a/matrix/install/command.py
+++ b/matrix/install/command.py
@@ -81,21 +81,26 @@ class DTCommand(DTCommandAbs):
                 return
         else:
             os_family = get_os_family()
-        # make sure the app is not already installed
-        installed_version = get_most_recent_version_installed(os_family, webgl)
-        if installed_version is not None and not parsed.update:
-            dtslogger.info(f"Found version 'v{installed_version}' already installed. \nUse "
-                           f"-U/--update to update to the latest version (if any is available).")
-            return
-        # get latest version available on the DCSS
-        latest_version = get_latest_version(os_family, webgl)
-        latest = latest_version + "-" + ("webgl" if webgl else os_family)
-        # compare installed and latest versions
-        if installed_version:
-            if installed_version == latest:
+        version = parsed.version
+        if version:
+            latest_version = version
+        else:
+            # make sure the app is not already installed
+            installed_version = get_most_recent_version_installed(os_family, webgl)
+            if installed_version is not None and not parsed.update:
+                dtslogger.info(f"Found version 'v{installed_version}' already installed. \nUse "
+                            f"-U/--update to update to the latest version (if any is available).")
                 return
-            app_dir = os.path.join(APP_RELEASES_DIR, f"v{installed_version}")
-            subprocess.check_call(["rm", "-rf", app_dir])
+            # get latest version available on the DCSS
+            latest_version = get_latest_version(os_family, webgl)
+        latest = latest_version + "-" + ("webgl" if webgl else os_family)
+        if not version:
+            # compare installed and latest versions
+            if installed_version:
+                if installed_version == latest:
+                    return
+                app_dir = os.path.join(APP_RELEASES_DIR, f"v{installed_version}")
+                subprocess.check_call(["rm", "-rf", app_dir])
         # make sure the same version is not already installed (unless forced)
         app_dir = os.path.join(APP_RELEASES_DIR, f"v{latest}")
         if os.path.isdir(app_dir):

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -256,8 +256,9 @@ class DTCommand(DTCommandAbs):
                     return
             else:
                 os_family = get_os_family()
-            if parsed.version:
-                version = parsed.version
+            version = parsed.version
+            if version:
+                shell.include.matrix.install.command(shell, ("--version", version))
             else:
                 args = ["--update"]
                 if browser:


### PR DESCRIPTION
This pull request introduces support for specifying a particular version to release or install in the `release`, `install`, and `run` commands. The main changes include adding a `--version` argument, updating logic to handle user-specified versions, and ensuring that version checks and updates behave correctly when a version is provided.

**Feature: Version selection support**

* Added a `--version` (or `-v`) argument to the `release` command, allowing users to specify a version to release instead of always using the one in the metadata.
* Updated the `install` command to accept a `--version` argument, enabling installation of a specific version if provided.

**Logic updates for version handling**

* Modified the `release` command logic to use the user-specified version if present, and only perform duplicate release checks and "mark as latest" actions when a version is not explicitly specified. [[1]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L83-R91) [[2]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427R101) [[3]](diffhunk://#diff-a8264ba45677d56f8742204d44d6e69d14b11e2dc56654a294478ca720a1c427L132-R141)
* Updated the `install` command to skip version comparison checks if a specific version is requested, ensuring it doesn't block installation of an already installed version.

**Integration with run command**

* Changed the `run` command to pass the `--version` argument to the `install` command if a version is specified, ensuring consistent version handling across commands.