### PR TITLE
DTSW-7663-Update-the-Duckietown-Shell-commands-for-the-Duckietown-Viewer-on-macOS-and-Windows

### DIFF
--- a/duckiebot/calibrate_extrinsics/command.py
+++ b/duckiebot/calibrate_extrinsics/command.py
@@ -1,7 +1,7 @@
 from dt_shell import DTCommandAbs, DTShell
 from utils.assets_utils import get_asset_icon_path
 from utils.duckietown_viewer_utils import \
-    ensure_duckietown_viewer_installed, launch_viewer
+    ensure_duckietown_viewer_installed, launch_viewer, resolve_os_family
 
 # NOTE: this must match the name of the launcher in the dt-duckietown-viewer project
 LAUNCHER_NAME = "extrinsics_calibrator"
@@ -18,16 +18,19 @@ class DTCommand(DTCommandAbs):
             parsed = DTCommand.parser.parse_args(args)
         # ---
         # make sure the app is installed
-        ensure_duckietown_viewer_installed()
+        browser = parsed.browser
+        os_family = resolve_os_family(parsed.os_family, browser)
+        ensure_duckietown_viewer_installed(os_family)
         # launch viewer
         launch_viewer(
             LAUNCHER_NAME,
+            os_family=os_family,
             robot=parsed.robot,
             verbose=parsed.verbose,
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
-            browser=parsed.browser,
+            browser=browser,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/calibrate_extrinsics/configuration.py
+++ b/duckiebot/calibrate_extrinsics/configuration.py
@@ -2,6 +2,7 @@ import argparse
 from dt_shell.commands import DTCommandConfigurationAbs
 from dt_shell.environments import ShellCommandEnvironmentAbs
 from typing import Optional, List
+from utils.duckietown_viewer_utils import SUPPORTED_OS_FAMILIES
 
 class DTCommandConfiguration(DTCommandConfigurationAbs):
     @classmethod
@@ -55,6 +56,14 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Run in browser mode"
+        )
+        parser.add_argument(
+            "-os",
+            "--os-family",
+            default="",
+            type=str,
+            choices=SUPPORTED_OS_FAMILIES,
+            help="Run for a given os-family",
         )
         parser.add_argument(
             "robot",

--- a/duckiebot/calibrate_intrinsics/command.py
+++ b/duckiebot/calibrate_intrinsics/command.py
@@ -1,7 +1,7 @@
 from dt_shell import DTCommandAbs, DTShell
 from utils.assets_utils import get_asset_icon_path
 from utils.duckietown_viewer_utils import \
-    ensure_duckietown_viewer_installed, launch_viewer
+    ensure_duckietown_viewer_installed, launch_viewer, resolve_os_family
 
 # NOTE: this must match the name of the launcher in the dt-duckietown-viewer project
 LAUNCHER_NAME = "intrinsics_calibrator"
@@ -18,16 +18,19 @@ class DTCommand(DTCommandAbs):
             parsed = DTCommand.parser.parse_args(args)
         # ---
         # make sure the app is installed
-        ensure_duckietown_viewer_installed()
+        browser = parsed.browser
+        os_family = resolve_os_family(parsed.os_family, browser)
+        ensure_duckietown_viewer_installed(os_family)
         # launch viewer
         launch_viewer(
             LAUNCHER_NAME,
+            os_family=os_family,
             robot=parsed.robot,
             verbose=parsed.verbose,
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
-            browser=parsed.browser,
+            browser=browser,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/calibrate_intrinsics/configuration.py
+++ b/duckiebot/calibrate_intrinsics/configuration.py
@@ -2,6 +2,7 @@ import argparse
 from dt_shell.commands import DTCommandConfigurationAbs
 from dt_shell.environments import ShellCommandEnvironmentAbs
 from typing import Optional, List
+from utils.duckietown_viewer_utils import SUPPORTED_OS_FAMILIES
 
 class DTCommandConfiguration(DTCommandConfigurationAbs):
     @classmethod
@@ -55,6 +56,14 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Run in browser mode"
+        )
+        parser.add_argument(
+            "-os",
+            "--os-family",
+            default="",
+            type=str,
+            choices=SUPPORTED_OS_FAMILIES,
+            help="Run for a given os-family",
         )
         parser.add_argument(
             "robot",

--- a/duckiebot/image_viewer/command.py
+++ b/duckiebot/image_viewer/command.py
@@ -1,7 +1,7 @@
 from dt_shell import DTCommandAbs, DTShell
 from utils.assets_utils import get_asset_icon_path
 from utils.duckietown_viewer_utils import \
-    ensure_duckietown_viewer_installed, launch_viewer
+    ensure_duckietown_viewer_installed, launch_viewer, resolve_os_family
 
 # NOTE: this must match the name of the launcher in the dt-duckietown-viewer project
 LAUNCHER_NAME = "image_viewer"
@@ -18,16 +18,19 @@ class DTCommand(DTCommandAbs):
             parsed = DTCommand.parser.parse_args(args)
         # ---
         # make sure the app is installed
-        ensure_duckietown_viewer_installed()
+        browser = parsed.browser
+        os_family = resolve_os_family(parsed.os_family, browser)
+        ensure_duckietown_viewer_installed(os_family)
         # launch viewer
         launch_viewer(
             LAUNCHER_NAME,
+            os_family=os_family,
             robot=parsed.robot,
             verbose=parsed.verbose,
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
-            browser=parsed.browser,
+            browser=browser,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/image_viewer/configuration.py
+++ b/duckiebot/image_viewer/configuration.py
@@ -2,6 +2,7 @@ import argparse
 from dt_shell.commands import DTCommandConfigurationAbs
 from dt_shell.environments import ShellCommandEnvironmentAbs
 from typing import Optional, List
+from utils.duckietown_viewer_utils import SUPPORTED_OS_FAMILIES
 
 class DTCommandConfiguration(DTCommandConfigurationAbs):
     @classmethod
@@ -55,6 +56,14 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Run in browser mode"
+        )
+        parser.add_argument(
+            "-os",
+            "--os-family",
+            default="",
+            type=str,
+            choices=SUPPORTED_OS_FAMILIES,
+            help="Run for a given os-family",
         )
         parser.add_argument(
             "robot",

--- a/duckiebot/keyboard_control/command.py
+++ b/duckiebot/keyboard_control/command.py
@@ -4,6 +4,7 @@ from utils.assets_utils import get_asset_icon_path
 from utils.duckietown_viewer_utils import (
     ensure_duckietown_viewer_installed,
     launch_viewer,
+    resolve_os_family,
 )
 
 # NOTE: this must match the name of the launcher in the dt-duckietown-viewer project
@@ -21,16 +22,19 @@ class DTCommand(DTCommandAbs):
             parsed = DTCommand.parser.parse_args(args)
         # ---
         # make sure the app is installed
-        ensure_duckietown_viewer_installed()
+        browser = parsed.browser
+        os_family = resolve_os_family(parsed.os_family, browser)
+        ensure_duckietown_viewer_installed(os_family)
         # launch viewer
         launch_viewer(
             LAUNCHER_NAME,
+            os_family=os_family,
             robot=parsed.robot,
             verbose=parsed.verbose,
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
-            browser=parsed.browser,
+            browser=browser,
             window_args={
                 "height": 418,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/keyboard_control/configuration.py
+++ b/duckiebot/keyboard_control/configuration.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 
 from dt_shell.commands import DTCommandConfigurationAbs
 from dt_shell.environments import ShellCommandEnvironmentAbs
+from utils.duckietown_viewer_utils import SUPPORTED_OS_FAMILIES
 
 
 class DTCommandConfiguration(DTCommandConfigurationAbs):
@@ -51,6 +52,14 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Run in browser mode"
+        )
+        parser.add_argument(
+            "-os",
+            "--os-family",
+            default="",
+            type=str,
+            choices=SUPPORTED_OS_FAMILIES,
+            help="Run for a given os-family",
         )
         parser.add_argument(
             "robot",

--- a/duckiebot/led_control/command.py
+++ b/duckiebot/led_control/command.py
@@ -1,7 +1,7 @@
 from dt_shell import DTCommandAbs, DTShell
 from utils.assets_utils import get_asset_icon_path
 from utils.duckietown_viewer_utils import \
-    ensure_duckietown_viewer_installed, launch_viewer
+    ensure_duckietown_viewer_installed, launch_viewer, resolve_os_family
 
 # NOTE: this must match the name of the launcher in the dt-duckietown-viewer project
 LAUNCHER_NAME = "led_controller"
@@ -18,16 +18,19 @@ class DTCommand(DTCommandAbs):
             parsed = DTCommand.parser.parse_args(args)
         # ---
         # make sure the app is installed
-        ensure_duckietown_viewer_installed()
+        browser = parsed.browser
+        os_family = resolve_os_family(parsed.os_family, browser)
+        ensure_duckietown_viewer_installed(os_family)
         # launch viewer
         launch_viewer(
             LAUNCHER_NAME,
+            os_family=os_family,
             robot=parsed.robot,
             verbose=parsed.verbose,
             fullscreen=parsed.fullscreen,
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
-            browser=parsed.browser,
+            browser=browser,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/led_control/configuration.py
+++ b/duckiebot/led_control/configuration.py
@@ -2,6 +2,7 @@ import argparse
 from dt_shell.commands import DTCommandConfigurationAbs
 from dt_shell.environments import ShellCommandEnvironmentAbs
 from typing import Optional, List
+from utils.duckietown_viewer_utils import SUPPORTED_OS_FAMILIES
 
 class DTCommandConfiguration(DTCommandConfigurationAbs):
     @classmethod
@@ -55,6 +56,14 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             default=False,
             action="store_true",
             help="Run in browser mode"
+        )
+        parser.add_argument(
+            "-os",
+            "--os-family",
+            default="",
+            type=str,
+            choices=SUPPORTED_OS_FAMILIES,
+            help="Run for a given os-family",
         )
         parser.add_argument(
             "robot",

--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -33,26 +33,92 @@ APP_LOCAL_DIR = os.path.join(USER_DATA_DIR, APP_NAME)
 APP_RELEASES_DIR = os.path.join(APP_LOCAL_DIR, "releases")
 
 AVAHI_SOCKET = "/var/run/avahi-daemon/socket"
+SUPPORTED_OS_FAMILIES = ("linux", "macos", "windows")
 
 WindowArgs = Dict[str, Union[int, float, str]]
 
 
+def linux_path_to_windows(path: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["wslpath", "-w", path],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_installed_windows_app_path() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["cmd.exe", "/c", "echo %LOCALAPPDATA%"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode != 0:
+            return None
+        windows_path = result.stdout.strip()
+        result2 = subprocess.run(
+            ["wslpath", windows_path],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result2.returncode != 0:
+            return None
+        wsl_path = result2.stdout.strip()
+        search_dir = os.path.join(wsl_path, "Programs", APP_NAME)
+        pattern = os.path.join(search_dir, "*.exe")
+        matches = [
+            file for file in glob.glob(pattern)
+            if "uninstall" not in file.lower()
+        ]
+        return matches[0] if matches else None
+    except Exception:
+        return None
+
+
 def get_os_family() -> str:
+    if os.path.exists("/proc/version"):
+        with open("/proc/version", "r") as f:
+            if "microsoft" in f.read().lower():
+                return "windows"
     if sys.platform.startswith('linux'):
-        machine = platform.machine()
-        return "linux-arm64" if machine.lower() in ("aarch64", "arm64") else "linux"
+        return "linux"
     elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
         return "windows"
     elif sys.platform.startswith('darwin'):
         return "macos"
 
 
-def get_latest_version(os_family: str = None) -> Optional[str]:
+def resolve_os_family(os_family: str = "", browser: bool = False) -> str:
+    if os_family:
+        if browser:
+            raise UserError("You cannot use -os/--os-family and --browser together.")
+        if os_family not in SUPPORTED_OS_FAMILIES:
+            raise UserError(
+                f"Unsupported os-family '{os_family}'. "
+                f"Supported values are: {', '.join(SUPPORTED_OS_FAMILIES)}."
+            )
+        return os_family
+    os_family = get_os_family()
+    machine = platform.machine()
+    if machine.lower() in ("aarch64", "arm64"):
+        os_family += "-arm64"
+    return os_family
+
+
+def get_latest_version(os_family: str = "") -> Optional[str]:
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
     # get latest version
-    os_family = os_family or get_os_family()
     latest_version_obj = os.path.join(DCSS_APP_DIR, f"latest-{os_family}")
     try:
         download = storage.download(latest_version_obj)
@@ -62,8 +128,8 @@ def get_latest_version(os_family: str = None) -> Optional[str]:
     return download.data.decode("ascii").strip()
 
 
-def get_all_installed_releases() -> List[str]:
-    app_dir = os.path.join(APP_RELEASES_DIR, "*")
+def get_all_installed_releases(os_family: str = "") -> List[str]:
+    app_dir = os.path.join(APP_RELEASES_DIR, f"*-{os_family}")
     dirs = glob.glob(app_dir)
     version_regex = r"v([0-9]+)\.([0-9]+)\.([0-9]+)"
     version_pattern = re.compile(version_regex)
@@ -71,46 +137,45 @@ def get_all_installed_releases() -> List[str]:
     return list(map(lambda p: os.path.basename(p)[1:], filter(is_release_dir, dirs)))
 
 
-def get_most_recent_version_installed() -> Optional[str]:
-    releases = get_all_installed_releases()
+def get_most_recent_version_installed(os_family: str = "") -> Optional[str]:
+    releases = get_all_installed_releases(os_family)
     release = None
     for r in releases:
         if release is None or versiontuple(r) > versiontuple(release):
             release = r
-    return release
+    if release is None:
+        return None
+    split_release = release.split("-")
+    return split_release[0]
 
 
-def get_path_to_install(version: str):
-    app_dir = os.path.join(APP_RELEASES_DIR, f"v{version}")
+def get_path_to_install(version: str, os_family: str = ""):
+    app_dir = os.path.join(APP_RELEASES_DIR, f"v{version}-{os_family}")
     if not os.path.isdir(app_dir):
         app_dir = None
     return app_dir
 
 
-def get_path_to_binary(version: str):
-    app_dir = get_path_to_install(version)
+def get_path_to_binary(version: str, os_family: str = ""):
+    app_dir = get_path_to_install(version, os_family)
     if app_dir is None:
         return None
-    system: str = get_os_family()
-    ext: str
-    if system.startswith("linux"):
+    if os_family == "macos":
+        return os.path.join(app_dir, "Duckietown Viewer.app")
+    if os_family == "linux":
         ext = "AppImage"
-        pattern = os.path.join(app_dir, f"{APP_NAME}-v{version}-*.{ext}")
-        matching_files = glob.glob(pattern)
-        if matching_files:
-            return matching_files[0]
-        return os.path.join(app_dir, f"{APP_NAME}-v{version}.{ext}")
-    elif system == "macos":
-        ext = "app"
-    elif system == "windows":
+    elif os_family == "windows":
         ext = "exe"
     else:
-        raise ValueError(f"Unknown platform '{system}'")
-    # ---
+        raise ValueError(f"Unknown platform '{os_family}'")
+    pattern = os.path.join(app_dir, f"{APP_NAME}-v{version}-*.{ext}")
+    matching_files = glob.glob(pattern)
+    if matching_files:
+        return matching_files[0]
     return os.path.join(app_dir, f"{APP_NAME}-v{version}.{ext}")
 
 
-def is_version_released(version: str, os_family: str = None) -> bool:
+def is_version_released(version: str, os_family: str = "") -> bool:
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
@@ -123,8 +188,7 @@ def is_version_released(version: str, os_family: str = None) -> bool:
         return False
 
 
-def remote_zip_obj(version: str, os_family: str = None):
-    os_family = os_family or get_os_family()
+def remote_zip_obj(version: str, os_family: str = ""):
     return os.path.join(DCSS_APP_RELEASES_DIR, f"{APP_NAME}-{version}-{os_family}.zip")
 
 
@@ -138,14 +202,14 @@ def mark_as_latest_version(token: str, version: str, os_family: str):
     upload.join()
 
 
-def ensure_duckietown_viewer_installed(log_prefix: str = None):
+def ensure_duckietown_viewer_installed(os_family: str = "", log_prefix: str = ""):
     shell: DTShell = dt_shell.shell
     log_prefix = log_prefix or " > "
 
     # make sure the app is not already installed
-    installed_version: Optional[str] = get_most_recent_version_installed()
+    installed_version: Optional[str] = get_most_recent_version_installed(os_family)
     # get latest version available on the DCSS
-    latest: Optional[str] = get_latest_version()
+    latest: Optional[str] = get_latest_version(os_family)
     if latest is None:
         dtslogger.error(f"{log_prefix}No version available for installation.")
         return
@@ -153,14 +217,14 @@ def ensure_duckietown_viewer_installed(log_prefix: str = None):
     if installed_version:
         if installed_version == latest:
             return
-        os.remove(get_path_to_binary(installed_version))
-        os.rmdir(get_path_to_install(installed_version))
+        os.remove(get_path_to_binary(installed_version, os_family))
+        os.rmdir(get_path_to_install(installed_version, os_family))
     # download new version
-    app_dir = os.path.join(APP_RELEASES_DIR, f"v{latest}")
+    app_dir = os.path.join(APP_RELEASES_DIR, f"v{latest}-{os_family}")
 
     dtslogger.info(f"{log_prefix}Downloading version v{latest}...")
     os.makedirs(app_dir, exist_ok=True)
-    zip_remote = remote_zip_obj(latest)
+    zip_remote = remote_zip_obj(latest, os_family)
     zip_local = os.path.join(app_dir, f"v{latest}.zip")
     shell.include.data.get.command(
         shell,
@@ -176,7 +240,61 @@ def ensure_duckietown_viewer_installed(log_prefix: str = None):
     # install
     dtslogger.info(f"{log_prefix}Installing...")
     subprocess.check_call(["unzip", f"v{latest}.zip"], cwd=app_dir)
-
+    # On macOS, extract the .app from the DMG
+    if os_family == "macos":
+        dmg_pattern = os.path.join(app_dir, "*.dmg")
+        dmg_files = glob.glob(dmg_pattern)
+        if dmg_files:
+            dmg_file = dmg_files[0]
+            dtslogger.info(f"{log_prefix}Mounting DMG...")
+            # Mount the DMG
+            result = subprocess.run(
+                ["hdiutil", "attach", dmg_file, "-nobrowse"],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                # Parse mount point from output
+                mount_point = None
+                for line in result.stdout.split("\n"):
+                    if "/Volumes/" in line:
+                        split_line = line.split("\t")
+                        mount_point = split_line[-1].strip()
+                        break
+                if mount_point:
+                    # Find .app in mounted volume
+                    app_pattern = os.path.join(mount_point, "*.app")
+                    app_files = glob.glob(app_pattern)
+                    if app_files:
+                        dtslogger.info(
+                            f"{log_prefix}Extracting application..."
+                        )
+                        # Copy .app to installation directory
+                        app_name = os.path.basename(app_files[0])
+                        dest_app = os.path.join(app_dir, app_name)
+                        subprocess.check_call(
+                            ["cp", "-R", app_files[0], dest_app]
+                        )
+                    # Unmount the DMG
+                    dtslogger.info(f"{log_prefix}Unmounting DMG...")
+                    subprocess.run(
+                        ["hdiutil", "detach", mount_point],
+                        capture_output=True
+                    )
+                # Remove the DMG file
+                os.remove(dmg_file)
+    if os_family == "windows":
+        # ensure the installer is executable (needed in WSL)
+        installer = get_path_to_binary(latest, os_family)
+        if installer and os.path.exists(installer):
+            installer_status = os.stat(installer)
+            os.chmod(installer, installer_status.st_mode | 0o111)
+        # run the NSIS installer silently so the app ends up in %LOCALAPPDATA%
+        dtslogger.info(
+            f"{log_prefix}Running Windows installer silently..."
+        )
+        subprocess.check_call([installer, "/S"])
+        dtslogger.info(f"{log_prefix}Windows installer completed.")
     # clean up
     dtslogger.info(f"{log_prefix}Removing temporary files...")
     os.remove(zip_local)
@@ -184,9 +302,9 @@ def ensure_duckietown_viewer_installed(log_prefix: str = None):
     dtslogger.info(f"{log_prefix}Installation completed successfully!")
 
 
-def launch_viewer(app: str, *, robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, browser: bool = False, window_args: Optional[WindowArgs] = None) \
+def launch_viewer(app: str, *, os_family: str = "", robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, browser: bool = False, window_args: Optional[WindowArgs] = None) \
         -> 'DuckietownViewerInstance':
-    viewer = DuckietownViewerInstance(verbose=verbose)
+    viewer = DuckietownViewerInstance(os_family, verbose)
     viewer.start(app, robot, fullscreen, menu, on_top, enable_hardware_acceleration, browser, window_args=window_args)
     return viewer
 
@@ -203,7 +321,8 @@ class DuckietownViewerInstance:
         "dashboard"
     ]
 
-    def __init__(self, verbose: bool = False):
+    def __init__(self, os_family: str = "", verbose: bool = False):
+        self._os_family: str = os_family
         self._verbose: bool = verbose
         # internal state
         self._backend: Optional[Container] = None
@@ -351,13 +470,22 @@ class DuckietownViewerInstance:
             app_config.append("--on-top")
         if enable_hardware_acceleration:
             app_config.append("--enable-hardware-acceleration")
-        app_bin = get_path_to_binary(get_most_recent_version_installed())
+        os_family = self._os_family
+        if os_family == "windows":
+            app_bin = get_installed_windows_app_path()
+        else:
+            app_bin = get_path_to_binary(get_most_recent_version_installed(os_family), os_family)
         # add extra arguments
         for k, v in args.items():
-            app_config.extend([f"--{k}", str(v)])
+            app_config.append(f"--{k}={v}")
         # run the app
         dtslogger.info("Launching viewer...")
-        app_cmd = [app_bin] + app_config
+        # On macOS, use 'open' command for .app bundles
+        if os_family == "macos" and app_bin.endswith(".app"):
+            # -W flag makes open wait until the application exits
+            app_cmd = ["open", "-W", app_bin, "--args"] + app_config
+        else:
+            app_cmd = [app_bin] + app_config
         dtslogger.debug(f"$ > {app_cmd}")
         self._frontend = subprocess.Popen(app_cmd)
 

--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -39,6 +39,14 @@ WindowArgs = Dict[str, Union[int, float, str]]
 
 
 def linux_path_to_windows(path: str) -> Optional[str]:
+    """Convert a Linux (WSL) filesystem path to its Windows equivalent using ``wslpath``.
+
+    Args:
+        path: The Linux/WSL path to convert.
+
+    Returns:
+        The Windows-style path string, or ``None`` if the conversion fails.
+    """
     try:
         result = subprocess.run(
             ["wslpath", "-w", path],
@@ -54,6 +62,14 @@ def linux_path_to_windows(path: str) -> Optional[str]:
 
 
 def get_installed_windows_app_path() -> Optional[str]:
+    """Locate the installed Duckietown Viewer executable on a Windows system (via WSL).
+
+    Looks for the app under ``%LOCALAPPDATA%\\Programs\\<APP_NAME>\\`` and returns
+    the path to the first ``.exe`` that is not an uninstaller.
+
+    Returns:
+        The path to the ``.exe`` binary, or ``None`` if it cannot be found.
+    """
     try:
         result = subprocess.run(
             ["cmd.exe", "/c", "echo %LOCALAPPDATA%"],
@@ -85,6 +101,15 @@ def get_installed_windows_app_path() -> Optional[str]:
 
 
 def get_os_family() -> str:
+    """Detect the current operating-system family.
+
+    Checks for WSL by inspecting ``/proc/version``, then falls back to
+    ``sys.platform`` to distinguish between ``"linux"``, ``"windows"``,
+    and ``"macos"``.
+
+    Returns:
+        One of ``"linux"``, ``"windows"``, or ``"macos"``.
+    """
     if os.path.exists("/proc/version"):
         with open("/proc/version", "r") as f:
             if "microsoft" in f.read().lower():
@@ -98,6 +123,24 @@ def get_os_family() -> str:
 
 
 def resolve_os_family(os_family: str = "", browser: bool = False) -> str:
+    """Resolve and validate the target OS family string.
+
+    When *os_family* is empty the value is auto-detected via :func:`get_os_family`
+    and an ``"-arm64"`` suffix is appended when running on ARM hardware.
+
+    Args:
+        os_family: Explicit OS family override (e.g. ``"linux"``, ``"macos"``,
+            ``"windows"``).  Pass an empty string for auto-detection.
+        browser: Whether the caller intends to open a browser instead of the
+            native app.  Mutually exclusive with a non-empty *os_family*.
+
+    Returns:
+        The resolved OS family string, potentially suffixed with ``"-arm64"``.
+
+    Raises:
+        UserError: If *os_family* and *browser* are both specified, or if
+            *os_family* is not in :data:`SUPPORTED_OS_FAMILIES`.
+    """
     if os_family:
         if browser:
             raise UserError("You cannot use -os/--os-family and --browser together.")
@@ -115,6 +158,16 @@ def resolve_os_family(os_family: str = "", browser: bool = False) -> str:
 
 
 def get_latest_version(os_family: str = "") -> Optional[str]:
+    """Fetch the latest available version string from the Duckietown Cloud Storage.
+
+    Args:
+        os_family: The OS family for which to look up the latest version
+            (e.g. ``"linux"``, ``"macos"``).  An empty string means no suffix.
+
+    Returns:
+        The version string (e.g. ``"1.2.3"``), or ``None`` if no release has
+        been published for the given OS family.
+    """
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
@@ -129,6 +182,14 @@ def get_latest_version(os_family: str = "") -> Optional[str]:
 
 
 def get_all_installed_releases(os_family: str = "") -> List[str]:
+    """Return the version strings of all locally installed releases.
+
+    Args:
+        os_family: The OS family to filter releases by.
+
+    Returns:
+        A list of version strings (e.g. ``["1.0.0-linux", "1.2.3-linux"]``).
+    """
     app_dir = os.path.join(APP_RELEASES_DIR, f"*-{os_family}")
     dirs = glob.glob(app_dir)
     version_regex = r"v([0-9]+)\.([0-9]+)\.([0-9]+)"
@@ -138,6 +199,15 @@ def get_all_installed_releases(os_family: str = "") -> List[str]:
 
 
 def get_most_recent_version_installed(os_family: str = "") -> Optional[str]:
+    """Find the highest-versioned locally installed release.
+
+    Args:
+        os_family: The OS family to filter releases by.
+
+    Returns:
+        The version string of the most recent locally installed release
+        (e.g. ``"1.2.3"``), or ``None`` if nothing is installed.
+    """
     releases = get_all_installed_releases(os_family)
     release = None
     for r in releases:
@@ -150,6 +220,16 @@ def get_most_recent_version_installed(os_family: str = "") -> Optional[str]:
 
 
 def get_path_to_install(version: str, os_family: str = ""):
+    """Return the local installation directory for a specific version.
+
+    Args:
+        version: The version string to look up (e.g. ``"1.2.3"``).
+        os_family: The OS family for which the version was installed.
+
+    Returns:
+        The absolute path to the installation directory, or ``None`` if the
+        directory does not exist.
+    """
     app_dir = os.path.join(APP_RELEASES_DIR, f"v{version}-{os_family}")
     if not os.path.isdir(app_dir):
         app_dir = None
@@ -157,6 +237,22 @@ def get_path_to_install(version: str, os_family: str = ""):
 
 
 def get_path_to_binary(version: str, os_family: str = ""):
+    """Return the path to the executable binary for a specific installed version.
+
+    For macOS the path points to the ``.app`` bundle; for Linux it is an
+    ``AppImage``; for Windows it is an ``.exe``.
+
+    Args:
+        version: The version string (e.g. ``"1.2.3"``).
+        os_family: The OS family (``"linux"``, ``"macos"``, or ``"windows"``).
+
+    Returns:
+        The path to the binary, or ``None`` if the installation directory does
+        not exist.
+
+    Raises:
+        ValueError: If *os_family* is not a recognised platform.
+    """
     app_dir = get_path_to_install(version, os_family)
     if app_dir is None:
         return None
@@ -176,6 +272,16 @@ def get_path_to_binary(version: str, os_family: str = ""):
 
 
 def is_version_released(version: str, os_family: str = "") -> bool:
+    """Check whether a specific version has been published on the Duckietown Cloud Storage.
+
+    Args:
+        version: The version string to check (e.g. ``"1.2.3"``).
+        os_family: The OS family for which to check availability.
+
+    Returns:
+        ``True`` if the release archive exists in the cloud storage,
+        ``False`` otherwise.
+    """
     # create storage client
     client = DataClient()
     storage = client.storage(DCSS_SPACE_NAME)
@@ -189,10 +295,27 @@ def is_version_released(version: str, os_family: str = "") -> bool:
 
 
 def remote_zip_obj(version: str, os_family: str = ""):
+    """Build the cloud-storage object path for a release archive.
+
+    Args:
+        version: The version string (e.g. ``"1.2.3"``).
+        os_family: The OS family suffix (e.g. ``"linux"``, ``"macos"``).
+
+    Returns:
+        The object path (key) of the release ``.zip`` on the Duckietown Cloud
+        Storage Service.
+    """
     return os.path.join(DCSS_APP_RELEASES_DIR, f"{APP_NAME}-{version}-{os_family}.zip")
 
 
 def mark_as_latest_version(token: str, version: str, os_family: str):
+    """Upload a pointer file to the cloud storage that designates a version as the latest.
+
+    Args:
+        token: Authentication token for the Duckietown Cloud Storage Service.
+        version: The version string to mark as latest (e.g. ``"1.2.3"``).
+        os_family: The OS family for which this version should be marked latest.
+    """
     # create storage client
     client = DataClient(token)
     storage = client.storage(DCSS_SPACE_NAME)
@@ -203,6 +326,20 @@ def mark_as_latest_version(token: str, version: str, os_family: str):
 
 
 def ensure_duckietown_viewer_installed(os_family: str = "", log_prefix: str = ""):
+    """Download and install the Duckietown Viewer if a newer version is available.
+
+    Compares the most recently installed local version against the latest version
+    published on the cloud storage.  If the local version is absent or outdated
+    the new release is downloaded, extracted, and installed.  For Windows an NSIS
+    silent installer is executed; for macOS the ``.app`` bundle is extracted from
+    a DMG image.
+
+    Args:
+        os_family: The OS family to install the viewer for.  Auto-detected when
+            empty.
+        log_prefix: Prefix string prepended to every log message (defaults to
+            ``" > "``).
+    """
     shell: DTShell = dt_shell.shell
     log_prefix = log_prefix or " > "
 
@@ -304,12 +441,53 @@ def ensure_duckietown_viewer_installed(os_family: str = "", log_prefix: str = ""
 
 def launch_viewer(app: str, *, os_family: str = "", robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, browser: bool = False, window_args: Optional[WindowArgs] = None) \
         -> 'DuckietownViewerInstance':
+    """Create and start a :class:`DuckietownViewerInstance`.
+
+    This is a convenience wrapper that instantiates the viewer, calls
+    :meth:`DuckietownViewerInstance.start`, and returns the instance.
+
+    Args:
+        app: The name of the viewer app to launch (must be one of
+            :attr:`DuckietownViewerInstance._KNOWN_APPS`).
+        os_family: Target OS family string.  Auto-detected when empty.
+        robot: Hostname or IP of the robot to connect to.  Required unless
+            *window_args* contains a ``"url"`` key.
+        verbose: When ``True`` the backend container logs are printed to stdout.
+        fullscreen: Launch the viewer in fullscreen mode.
+        menu: Show the viewer menu bar.
+        on_top: Keep the viewer window on top of all other windows.
+        enable_hardware_acceleration: Enable GPU hardware acceleration in the
+            viewer.
+        browser: Open the viewer URL in the system browser instead of the
+            native app window.
+        window_args: Extra keyword arguments forwarded to the frontend binary
+            as ``--key=value`` CLI flags.  A ``"url"`` key bypasses the
+            backend entirely.
+
+    Returns:
+        The :class:`DuckietownViewerInstance` after it has finished running.
+    """
     viewer = DuckietownViewerInstance(os_family, verbose)
     viewer.start(app, robot, fullscreen, menu, on_top, enable_hardware_acceleration, browser, window_args=window_args)
     return viewer
 
 
 class DuckietownViewerInstance:
+    """Manages the lifecycle of a Duckietown Viewer session.
+
+    A session consists of two components:
+
+    * **Backend** – a Docker container that serves the viewer web application
+      and communicates with a physical or virtual Duckiebot over the network.
+    * **Frontend** – the native desktop application (or browser tab) that
+      renders the viewer UI by connecting to the backend HTTP server.
+
+    Typical usage::
+
+        viewer = DuckietownViewerInstance(os_family="linux")
+        viewer.start("image_viewer", robot="my-duckiebot")
+    """
+
     _BACKEND_DOCKER_IMAGE = "{registry}/duckietown/dt-duckietown-viewer:{distro}"
     _BACKEND_REMOTE_PORT = 8000
     _KNOWN_APPS = [
@@ -322,6 +500,14 @@ class DuckietownViewerInstance:
     ]
 
     def __init__(self, os_family: str = "", verbose: bool = False):
+        """Initialise a new viewer instance.
+
+        Args:
+            os_family: The OS family used to locate the correct frontend binary.
+                Auto-detected when empty.
+            verbose: When ``True`` the Docker backend logs are streamed to
+                stdout in a background thread.
+        """
         self._os_family: str = os_family
         self._verbose: bool = verbose
         # internal state
@@ -330,6 +516,23 @@ class DuckietownViewerInstance:
         self._backend_url: Optional[str] = None
 
     def start(self, app: str, robot: Optional[str], fullscreen: Optional[bool], menu: Optional[bool], on_top: Optional[bool], enable_hardware_acceleration: Optional[bool], browser: bool = False, window_args: Optional[WindowArgs] = None):
+        """Start the viewer backend (if needed) and then the frontend, blocking until exit.
+
+        If *window_args* contains a ``"url"`` key the backend is skipped and
+        the frontend opens that URL directly.  In browser mode the method
+        blocks until a ``KeyboardInterrupt`` is received.
+
+        Args:
+            app: Name of the viewer app to run.
+            robot: Hostname or IP of the target robot.
+            fullscreen: Pass ``--fullscreen`` to the frontend.
+            menu: Pass ``--menu`` to the frontend.
+            on_top: Pass ``--on-top`` to the frontend.
+            enable_hardware_acceleration: Pass ``--enable-hardware-acceleration``
+                to the frontend.
+            browser: Open in the system browser instead of the native app.
+            window_args: Additional ``--key=value`` arguments for the frontend.
+        """
         if "url" not in window_args.keys():
             self._start_backend(app, robot)
             if not self._wait_backend_ready():
@@ -351,6 +554,21 @@ class DuckietownViewerInstance:
         self._stop()
 
     def _start_backend(self, app: str, robot: str):
+        """Pull the backend Docker image and start a container for the given app.
+
+        The container exposes the backend HTTP server on a random host port.
+        An Avahi socket is mounted into the container when available to enable
+        mDNS resolution.  A shutdown hook is registered so the container is
+        stopped when the shell exits.
+
+        Args:
+            app: The viewer app identifier (must be in :attr:`_KNOWN_APPS`).
+            robot: Hostname or IP of the robot to connect to.
+
+        Raises:
+            ValueError: If *app* is not in :attr:`_KNOWN_APPS`.
+            UserError: If the robot's IP address cannot be resolved.
+        """
         import dt_shell
         # make sure the app is known
         if app not in self._KNOWN_APPS:
@@ -420,6 +638,16 @@ class DuckietownViewerInstance:
         self._backend = container
 
     def _wait_backend_ready(self) -> bool:
+        """Poll the backend HTTP server until it returns ``200 OK`` or a timeout is reached.
+
+        Retrieves the dynamically assigned host port from the running container,
+        then sends GET requests to ``http://localhost:<port>/`` at 0.5-second
+        intervals.
+
+        Returns:
+            ``True`` when the backend is ready, ``False`` if the 10-second
+            timeout expires before a successful response is received.
+        """
         container: Container = self._backend
         container_name: str = container.name
         dtslogger.debug(f"Waiting for container '{container_name}' to be ready...")
@@ -457,6 +685,23 @@ class DuckietownViewerInstance:
             time.sleep(0.5)
 
     def _start_frontend(self, fullscreen: Optional[bool], menu: Optional[bool], on_top: Optional[bool], enable_hardware_acceleration: Optional[bool], args: WindowArgs):
+        """Locate the frontend binary and launch it as a subprocess.
+
+        Builds the CLI argument list from the supplied options, resolves the
+        platform-specific binary path, and spawns the process with
+        :class:`subprocess.Popen`.  On macOS ``.app`` bundles are launched via
+        ``open -W``.
+
+        Args:
+            fullscreen: Pass ``--fullscreen`` to the binary.
+            menu: Pass ``--menu`` to the binary.
+            on_top: Pass ``--on-top`` to the binary.
+            enable_hardware_acceleration: Pass ``--enable-hardware-acceleration``
+                to the binary.
+            args: Additional ``key``/``value`` pairs appended as
+                ``--key=value`` flags.  A ``"url"`` key overrides the backend
+                URL.
+        """
         app_config = ["--no-sandbox"]
         if "url" not in args.keys():
             if self._backend_url is None:
@@ -490,10 +735,12 @@ class DuckietownViewerInstance:
         self._frontend = subprocess.Popen(app_cmd)
 
     def _join_frontend(self):
+        """Block until the frontend process exits."""
         self._frontend.wait()
         dtslogger.info("Viewer closed. Exiting...")
 
     def _stop(self):
+        """Terminate the frontend process and stop the backend container."""
         if self._frontend is not None:
             self._frontend.terminate()
         if self._backend is not None:


### PR DESCRIPTION
This pull request introduces support for specifying the operating system family (`os-family`) when launching or installing the Duckietown Viewer application across multiple Duckiebot command modules. This change enables more precise selection and handling of platform-specific application binaries, improving compatibility and user experience, especially in environments like WSL or when running on different architectures.

The most important changes are:

**Support for OS Family Selection:**

* Added a new `--os-family` (`-os`) command-line argument to the configuration of all relevant Duckiebot modules (`calibrate_extrinsics`, `calibrate_intrinsics`, `image_viewer`, `keyboard_control`, `led_control`), allowing users to explicitly specify the target operating system family. [[1]](diffhunk://#diff-29ec1ccac97f8a17602434b417717a14ab9902271954d64c609a05a77652689aR59-R65) [[2]](diffhunk://#diff-3a841b3192eaec6f6870069a20d420865b4d8e00a564396a6efbfea2109facd9R59-R65) [[3]](diffhunk://#diff-96ac15fded4bfe1d72c33acef6378e281bb40349ab16d173809d11aa55ea93b3R59-R65) [[4]](diffhunk://#diff-9c65bf1bcf0b5cc10af759ba2f024e17089c99a13173a16363c80be98d346d93R55-R61) [[5]](diffhunk://#diff-bc8c02f77f5960bac256a7403050f38bf06c2d17b1023cfde5fec17021556422R59-R65)

**Command Logic Updates:**

* Updated command logic in each module to resolve the effective OS family using the new `resolve_os_family` utility, and to pass this value to both the installation and viewer launch routines. This ensures the correct binary is installed and launched for the specified or detected platform. [[1]](diffhunk://#diff-5bc8b4ec232c7b5ff2aa3f27c877bdfc3d0575afb3d521aab742512e92911bf1L21-R33) [[2]](diffhunk://#diff-951e5944015e11c7c1b448152336602675d9180d863cd93f3080af4503366648L21-R33) [[3]](diffhunk://#diff-95d2b4e8fa0f01366acce226de332a0b4ede549f5f6967dfd2a7724c4731c721L21-R33) [[4]](diffhunk://#diff-a5093827d0486a87c42434637b3d893d32308d45b55bd4f02cb4b3cc70b0c552L24-R37) [[5]](diffhunk://#diff-ac53a6a078c53da505b263173e7be27fc91460952d769b54e84e35d7d492d670L21-R33)

**Utilities and Installation Improvements:**

* Refactored and extended `utils/duckietown_viewer_utils.py` to:
  - Add the `resolve_os_family` function for robust OS family determination and validation.
  - Update installation and binary path resolution functions to use the OS family as part of their logic and file paths.
  - Add helpers for WSL/Windows path resolution and improved version management per OS family. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eR36-L55) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL65-R178) [[3]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL126-R191) [[4]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL141-R227)

**Imports and Consistency:**

* Updated imports in all affected modules to include the new `resolve_os_family` utility, ensuring consistent usage across the codebase. [[1]](diffhunk://#diff-5bc8b4ec232c7b5ff2aa3f27c877bdfc3d0575afb3d521aab742512e92911bf1L4-R4) [[2]](diffhunk://#diff-951e5944015e11c7c1b448152336602675d9180d863cd93f3080af4503366648L4-R4) [[3]](diffhunk://#diff-95d2b4e8fa0f01366acce226de332a0b4ede549f5f6967dfd2a7724c4731c721L4-R4) [[4]](diffhunk://#diff-a5093827d0486a87c42434637b3d893d32308d45b55bd4f02cb4b3cc70b0c552R7) [[5]](diffhunk://#diff-ac53a6a078c53da505b263173e7be27fc91460952d769b54e84e35d7d492d670L4-R4)

These changes collectively improve cross-platform support and make the Duckietown Viewer tooling more robust and user-friendly for a wider range of development environments.