### PR TITLE
DTSW-7675 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -1,5 +1,9 @@
 name: Enforce Jira Key in PR Title and Branch
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/duckietown-shell-commands/security/code-scanning/1](https://github.com/duckietown/duckietown-shell-commands/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block either at the top level of the workflow (so it applies to all jobs) or within the specific job, granting only the minimal access needed. Since this workflow only reads PR title and branch information from the `github` context and does not write anything back to GitHub, it can safely operate with `read`-only permissions, specifically `pull-requests: read`. We can also explicitly set `contents: read` as a safe baseline equivalent to read-only defaults.

The single best fix here, without changing behavior, is to add a root-level `permissions` block just under the workflow `name:`. This will apply to `check-jira-key` and any future jobs that don’t override permissions. We should set:
```yaml
permissions:
  contents: read
  pull-requests: read
```
No other parts of the workflow need to change, and no additional imports or tools are required, since permissions are purely declarative in the YAML.

Concretely, in `.github/workflows/jira-pr-check.yml`, insert the `permissions:` block after line 1 (`name: Enforce Jira Key in PR Title and Branch`) and before the `on:` key. No other lines require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
