### PR TITLE
fix-wifi-test-in-dt-ros-interface-to-dynamically-detect-wireless-interface-instead-of-hard-coding-wlan-0-DTSW-7683

### DIFF
--- a/stack/stacks/ros1/duckiebot.yaml
+++ b/stack/stacks/ros1/duckiebot.yaml
@@ -13,6 +13,7 @@ services:
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+      - /data/config/robot_hardware:/data/config/robot_hardware:ro
 
   rosbridge-websocket:
     image: ${REGISTRY}/duckietown/dt-rosbridge-websocket:ente-${ARCH}


### PR DESCRIPTION
The ros-interface container needs access to /data/config/robot_hardware so that dt_robot_utils.get_robot_hardware() can detect the board type (e.g., JETSON_ORIN_NANO). Without this, the WiFi interface auto-detection falls back to wlan0 which doesn't exist on Orin Nano.
