### PR TITLE
DTSW-7684-Add-the-ability-to-route-robot-Docker-daemon-pulls-through-local-HTTP-proxy

### DIFF
--- a/duckiebot/update/command.py
+++ b/duckiebot/update/command.py
@@ -1,6 +1,13 @@
 import argparse
 import copy
-from typing import Optional, List, Dict
+import os
+import shutil
+import socket as _socket
+import subprocess
+import time
+import urllib.request
+from typing import Optional, Dict
+from urllib.parse import urlparse as _urlparse
 
 import questionary
 from docker import DockerClient
@@ -37,12 +44,231 @@ STACKS_TO_LOAD = {
     "ros1": "ros1/{robot_type}",
 }
 
+ROBOT_PROXY_DROP_IN = "/etc/systemd/system/docker.service.d/dts-proxy.conf"
+ROBOT_PROXY_SETUP_SCRIPT = "/usr/local/bin/dts-proxy-setup"
+ROBOT_PROXY_ENV_FILE = "/run/dts-proxy.env"
+SOCAT_LAN_PORT = 17897
+DOCKER_RESTART_TIMEOUT = 60
 
-def _config_node_directory_exists(client: DockerClient) -> bool:
+
+def _get_robot_image(client: DockerClient) -> str:
+    """Return a tag from an image already cached on the robot.
+
+    Using a pre-cached image avoids a Docker Hub pull which may not be reachable.
+    Falls back to 'alpine:3.23.3' in the unlikely case no images exist yet.
+    """
+    try:
+        for img in client.images.list():
+            if img.tags:
+                return img.tags[0]
+    except Exception:
+        pass
+    return "alpine:3.23.3"
+
+
+def _wait_for_docker(hostname: str, timeout: int = DOCKER_RESTART_TIMEOUT) -> None:
+    """Block until the robot's Docker daemon responds on its TCP endpoint after a restart.
+
+    Probes /version with a fresh connection each time — this is identical to what
+    get_client_OLD does, so success here guarantees the subsequent client creation
+    will not see a 'Connection refused'.
+    """
+    url = f"http://{hostname}:2375/version"
+    for _ in range(timeout):
+        time.sleep(1)
+        try:
+            urllib.request.urlopen(url, timeout=2)
+            return
+        except Exception:
+            pass
+    raise TimeoutError(f"Robot Docker daemon did not come back up within {timeout} seconds after restart.")
+
+
+def _setup_robot_proxy(client: DockerClient, proxy_url: str, no_proxy: str, run_image: str) -> None:
+    """Configure the robot's Docker daemon to pull through the given HTTP proxy."""
+    dtslogger.info(f"Configuring robot Docker daemon to use proxy: {proxy_url}")
+
+    # Parse host and port for the connectivity-check script.
+    _parsed_proxy = _urlparse(proxy_url)
+    proxy_host = _parsed_proxy.hostname or ""
+    proxy_port_str = str(_parsed_proxy.port or 80)
+
+    # Runtime env file written immediately so the very next Docker restart picks up the
+    # proxy. /run/ is a tmpfs on Linux and is cleared on every reboot, so a stale drop-in
+    # left behind after a reboot is harmless — the EnvironmentFile= directive will find no
+    # file and Docker starts without any proxy configured.
+    env_file_content = (
+        f"HTTP_PROXY={proxy_url}\n"
+        f"HTTPS_PROXY={proxy_url}\n"
+        f"NO_PROXY=localhost,127.0.0.1,{no_proxy}\n"
+    )
+
+    # Check script run by ExecStartPre= on every Docker restart: recreates
+    # /run/dts-proxy.env only if the proxy host is still reachable; otherwise clears it.
+    # This makes leftover configuration safe even without a reboot.
+    setup_script_content = (
+        "#!/bin/sh\n"
+        f'if python3 -c "import socket; socket.create_connection((\'{proxy_host}\', {proxy_port_str}), timeout=2).close()" 2>/dev/null; then\n'
+        f'    printf "HTTP_PROXY={proxy_url}\\nHTTPS_PROXY={proxy_url}\\nNO_PROXY=localhost,127.0.0.1,{no_proxy}\\n" > /run/dts-proxy.env\n'
+        "else\n"
+        "    : > /run/dts-proxy.env\n"
+        "fi\n"
+    )
+
+    # Drop-in: ExecStartPre= conditionally populates the env file before the daemon reads
+    # it. Both use the '-' prefix to tolerate absence/failure gracefully.
+    drop_in_content = (
+        "[Service]\n"
+        f"ExecStartPre=-{ROBOT_PROXY_SETUP_SCRIPT}\n"
+        "EnvironmentFile=-/run/dts-proxy.env\n"
+    )
+
+    drop_in_dir = os.path.dirname(ROBOT_PROXY_DROP_IN)
+    setup_script_dir = os.path.dirname(ROBOT_PROXY_SETUP_SCRIPT)
+
+    # Step 1: write all files via python3 in a privileged container.
+    # repr() handles all quoting and escaping automatically.
+    write_code = (
+        "import os; "
+        f"os.makedirs({repr('/host' + drop_in_dir)}, exist_ok=True); "
+        f"os.makedirs({repr('/host' + setup_script_dir)}, exist_ok=True); "
+        f"f=open({repr('/host' + ROBOT_PROXY_ENV_FILE)}, 'w'); f.write({repr(env_file_content)}); f.close(); "
+        f"f=open({repr('/host' + ROBOT_PROXY_SETUP_SCRIPT)}, 'w'); f.write({repr(setup_script_content)}); f.close(); "
+        f"os.chmod({repr('/host' + ROBOT_PROXY_SETUP_SCRIPT)}, 0o755); "
+        f"f=open({repr('/host' + ROBOT_PROXY_DROP_IN)}, 'w'); f.write({repr(drop_in_content)}); f.close()"
+    )
+    client.containers.run(
+        image=run_image,
+        entrypoint=["python3", "-c"],
+        command=[write_code],
+        volumes={"/": {"bind": "/host", "mode": "rw"}},
+        pid_mode="host",
+        privileged=True,
+        remove=True,
+        detach=False,
+    )
+    # Step 2: reload systemd and restart Docker in a detached container.
+    # The Docker restart will kill this container — that is expected and not an error.
+    restart_script = (
+        "nsenter -t 1 -m -u -i -n -p -- systemctl daemon-reload && "
+        "nsenter -t 1 -m -u -i -n -p -- systemctl restart docker"
+    )
+    try:
+        client.containers.run(
+            image=run_image,
+            entrypoint=["sh", "-c"],
+            command=[restart_script],
+            pid_mode="host",
+            privileged=True,
+            detach=True,
+        )
+    except Exception:
+        # Docker restart kills the container connection — this is expected
+        # The caller is responsible for waiting until the daemon is back up.
+        pass
+
+
+def _restore_robot_proxy(client: DockerClient, run_image: str) -> None:
+    """Remove the proxy drop-in from the robot and restart its Docker daemon."""
+    dtslogger.info("Restoring robot Docker daemon configuration...")
+    # Step 1: remove the proxy drop-in, check script, and env file
+    delete_script = f"rm -f /host{ROBOT_PROXY_DROP_IN} /host{ROBOT_PROXY_SETUP_SCRIPT} /host{ROBOT_PROXY_ENV_FILE}"
+    client.containers.run(
+        image=run_image,
+        entrypoint=["sh", "-c"],
+        command=[delete_script],
+        volumes={"/": {"bind": "/host", "mode": "rw"}},
+        pid_mode="host",
+        privileged=True,
+        remove=True,
+        detach=False,
+    )
+    # Step 2: reload systemd and restart Docker in a detached container.
+    restart_script = (
+        "nsenter -t 1 -m -u -i -n -p -- systemctl daemon-reload && "
+        "nsenter -t 1 -m -u -i -n -p -- systemctl restart docker"
+    )
+    try:
+        client.containers.run(
+            image=run_image,
+            entrypoint=["sh", "-c"],
+            command=[restart_script],
+            pid_mode="host",
+            privileged=True,
+            detach=True,
+        )
+    except Exception:
+        # Docker restart kills the container connection — this is expected
+        # The caller is responsible for waiting until the daemon is back up.
+        pass
+
+
+def _detect_local_proxy_port() -> Optional[int]:
+    """Return the port of a local HTTP proxy from env vars, or None if not set."""
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        val = os.environ.get(var, "")
+        if not val:
+            continue
+        try:
+            parsed = _urlparse(val)
+            if parsed.hostname == "127.0.0.1" and parsed.port:
+                dtslogger.info(f"Detected proxy from env {var}: port {parsed.port}")
+                return parsed.port
+        except Exception:
+            pass
+    return None
+
+
+_socat_process = None
+
+
+def _ensure_socat_forwarder(local_ip: str, lan_port: int, proxy_port: int) -> bool:
+    """Ensure socat is forwarding local_ip:lan_port -> 127.0.0.1:proxy_port.
+
+    Starts socat in the background if the port is not already bound.
+    Returns True if the forwarder is available after the call.
+    """
+    global _socat_process
+    # Already listening?
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.settimeout(1)
+    try:
+        s.connect((local_ip, lan_port))
+        s.close()
+        dtslogger.info(f"Socat forwarder already running on {local_ip}:{lan_port}.")
+        return True
+    except OSError:
+        pass
+    if not shutil.which("socat"):
+        dtslogger.error("socat is not installed. Install it with: sudo apt-get install -y socat")
+        return False
+    dtslogger.info(f"Starting socat forwarder {local_ip}:{lan_port} -> 127.0.0.1:{proxy_port} ...")
+    _socat_process = subprocess.Popen(
+        ["socat", f"TCP-LISTEN:{lan_port},bind={local_ip},fork,reuseaddr", f"TCP:127.0.0.1:{proxy_port}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(1)
+    s2 = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s2.settimeout(2)
+    try:
+        s2.connect((local_ip, lan_port))
+        s2.close()
+        dtslogger.info("Socat forwarder started.")
+        return True
+    except OSError:
+        dtslogger.error(f"Socat forwarder failed to start on {local_ip}:{lan_port}.")
+        if _socat_process is not None:
+            _socat_process.terminate()
+            _socat_process = None
+        return False
+
+
+def _config_node_directory_exists(client: DockerClient, run_image: str) -> bool:
     try:
         # Check if the /data/config/node directory exists
         client.containers.run(
-            image="alpine:3.23.3",
+            image=run_image,
             command=["test", "-d", "/data/config/node"],
             volumes={
                 "/data": {
@@ -57,12 +283,12 @@ def _config_node_directory_exists(client: DockerClient) -> bool:
         return False
     return True
 
-def _delete_config_node_directory(client: DockerClient) -> None:
+def _delete_config_node_directory(client: DockerClient, run_image: str) -> None:
     dtslogger.info("Deleting node configuration directory...")
     try:
         # Delete the /data/config/node directory
         client.containers.run(
-            image="alpine:3.23.3",
+            image=run_image,
             command=["rm", "-rf", "/data/config/node"],
             volumes={
                 "/data": {
@@ -217,53 +443,107 @@ class DTCommand(DTCommandAbs):
             img.format(registry=registry_to_use, distro=distro, arch=arch) for img in OTHER_IMAGES_TO_UPDATE
         ]
         client = get_client_OLD(hostname)
+        run_image: str = _get_robot_image(client)
         credentials: DockerCredentials = shell.profile.secrets.docker_credentials
-        login_client_OLD(client, credentials, registry_to_use, raise_on_error=False)
-        # it looks like the update is going to happen, mark the event
-        log_event_on_robot(robot, "duckiebot/update")
 
-        if _config_node_directory_exists(client):
-            if parsed.reset_node_configs:
-                _delete_config_node_directory(client)
-            else:
-                choice = input(
-                    "Reset node configurations after next boot? [Y/n]: "
-                )
-                if choice.lower() != "n":
-                    _delete_config_node_directory(client)
+        # If HTTPS_PROXY / HTTP_PROXY is set, forward the proxy to the robot via socat
+        # so its Docker daemon can pull images from docker.io through it.
+        robot_proxy_configured: bool = False
+        try:
+            s = _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM)
+            s.connect((_socket.gethostbyname(hostname), 80))
+            local_ip = s.getsockname()[0]
+            s.close()
+            proxy_port = _detect_local_proxy_port()
+            if proxy_port is not None:
+                _ensure_socat_forwarder(local_ip, SOCAT_LAN_PORT, proxy_port)
+                proxy_url = f"http://{local_ip}:{SOCAT_LAN_PORT}"
+                _setup_robot_proxy(client, proxy_url, hostname, run_image)
+                _wait_for_docker(hostname)
+                client = get_client_OLD(hostname)
+                robot_proxy_configured = True
+                dtslogger.info("Robot Docker daemon proxy configured; pulls will route through the proxy.")
+        except Exception as e:
+            dtslogger.warning(f"Could not auto-configure robot proxy: {e}. Continuing anyway.")
 
-        # stack/up options
-        stack_up_options = ["--machine", robot, "--detach"]
-        if not parsed.no_pull:
-            stack_up_options.append("--pull")
-
-        # call `stack up` command for all stacks to update
-        for project, stack in stacks.items():
-            dtslogger.info(f"Updating stack `{stack}`...")
-            success = shell.include.stack.up.command(shell, stack_up_options + [stack.strip(),])
-            if not success:
+        def _restore_proxy_if_needed():
+            if not robot_proxy_configured:
                 return
-
-        # update non-active images
-        if not parsed.no_pull:
-            for image in images:
-                dtslogger.info(f"Pulling image `{image}`...")
+            last_restore_error = None
+            for _attempt in range(3):
                 try:
-                    pull_image_OLD(image, client)
-                except NotFound:
-                    dtslogger.error(f"Image '{image}' not found on registry '{registry_to_use}'. Aborting.")
+                    if _attempt > 0:
+                        dtslogger.info(f"Retrying restore (attempt {_attempt + 1}/3)...")
+                    restore_client = get_client_OLD(hostname)
+                    _restore_robot_proxy(restore_client, run_image)
+                    _wait_for_docker(hostname)
+                    dtslogger.info("Robot Docker daemon configuration restored.")
+                    last_restore_error = None
+                    break
+                except Exception as e:
+                    last_restore_error = e
+            if last_restore_error is not None:
+                dtslogger.warning(
+                    f"Could not restore robot Docker daemon configuration: {last_restore_error}\n"
+                    f"To restore manually, SSH into the robot and run:\n"
+                    f"  sudo rm -f {ROBOT_PROXY_DROP_IN} {ROBOT_PROXY_SETUP_SCRIPT}\n"
+                    f"  sudo systemctl daemon-reload && sudo systemctl restart docker"
+                )
+
+        try:
+            login_client_OLD(client, credentials, registry_to_use, raise_on_error=False)
+            # it looks like the update is going to happen, mark the event
+            log_event_on_robot(robot, "duckiebot/update")
+
+            if _config_node_directory_exists(client, run_image):
+                if parsed.reset_node_configs:
+                    _delete_config_node_directory(client, run_image)
+                else:
+                    choice = input(
+                        "Reset node configurations after next boot? [Y/n]: "
+                    )
+                    if choice.lower() != "n":
+                        _delete_config_node_directory(client, run_image)
+
+            # stack/up options
+            stack_up_options = ["--machine", robot, "--detach"]
+            if not parsed.no_pull:
+                stack_up_options.append("--pull")
+
+            # call `stack up` command for all stacks to update
+            for project, stack in stacks.items():
+                dtslogger.info(f"Updating stack `{stack}`...")
+                success = shell.include.stack.up.command(shell, stack_up_options + [stack.strip(),])
+                if not success:
                     return
 
-        # set the distro on the robot
-        if kv.is_available():
-            if distro != rdistro:
-                dtslogger.info(f"Setting the distro '{distro}' on robot '{robot}'")
-            kv.set("robot/distro", distro, persist=True, fail_quietly=True)
-        else:
-            dtslogger.warning(f"Could not set the distro '{distro}' on robot '{robot}'")
+            # update non-active images
+            if not parsed.no_pull:
+                for image in images:
+                    dtslogger.info(f"Pulling image `{image}`...")
+                    try:
+                        pull_image_OLD(image, client)
+                    except NotFound:
+                        dtslogger.error(f"Image '{image}' not found on registry '{registry_to_use}'. Aborting.")
+                        return
 
-        # clean duckiebot (again)
-        if not parsed.no_clean:
-            shell.include.duckiebot.clean.command(shell, [robot, "--all", "--yes", "--untagged"])
+            # set the distro on the robot
+            if kv.is_available():
+                if distro != rdistro:
+                    dtslogger.info(f"Setting the distro '{distro}' on robot '{robot}'")
+                kv.set("robot/distro", distro, persist=True, fail_quietly=True)
+            else:
+                dtslogger.warning(f"Could not set the distro '{distro}' on robot '{robot}'")
+
+            # clean duckiebot (again)
+            if not parsed.no_clean:
+                shell.include.duckiebot.clean.command(shell, [robot, "--all", "--yes", "--untagged"])
+
+        except KeyboardInterrupt:
+            dtslogger.warning("Update interrupted by user.")
+        finally:
+            _restore_proxy_if_needed()
+            if _socat_process is not None and _socat_process.poll() is None:
+                _socat_process.terminate()
 
         dtslogger.info("Update completed!")

--- a/utils/docker_utils.py
+++ b/utils/docker_utils.py
@@ -246,7 +246,17 @@ def _login_client_OLD(
     """Raises CouldNotLogin"""
     password_hidden = hide_string(password)
     dtslogger.info(f"Logging in to {registry} as {username!r} with secret {password_hidden!r}")
-    res = client.login(username=username, password=password, registry=registry, reauth=True)
+    try:
+        res = client.login(username=username, password=password, registry=registry, reauth=True)
+    except dockerOLD.errors.APIError as e:
+        msg = f"Docker API error while logging in to {registry!r}: {e}"
+        if raise_on_error:
+            dtslogger.error(msg)
+            raise CouldNotLogin(msg) from e
+        else:
+            dtslogger.warning(msg)
+            dtslogger.warning("Continuing because raise_on_error = False.")
+            return
     dtslogger.debug(f"login response: {res}")
     # Status': 'Login Succeeded'
     if res.get("Status", None) == "Login Succeeded":


### PR DESCRIPTION
This pull request introduces robust support for using an HTTP proxy when updating a Duckiebot, ensuring that the robot's Docker daemon can pull images through a local proxy if one is detected. It adds logic to detect and forward a proxy, configures the robot's Docker daemon dynamically, and ensures cleanup and restoration of the robot's Docker configuration after the update. Several internal helper functions are added or updated to support these features, and error handling is improved for Docker login operations.

**Proxy and Docker daemon configuration:**

- Added detection of local HTTP(S) proxy environment variables and, if found, sets up a `socat` TCP forwarder from the host to the robot, enabling the robot's Docker daemon to pull images through the proxy. This includes starting and managing the `socat` process as needed. [[1]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acL3-R10) [[2]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acR47-R271)
- Introduced functions to programmatically configure (`_setup_robot_proxy`) and restore (`_restore_robot_proxy`) the robot's Docker daemon proxy settings by writing systemd drop-ins and scripts on the robot via privileged containers, with robust cleanup and retry logic. [[1]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acR47-R271) [[2]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acR446-R506) [[3]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acR542-R548)

**Image and container management:**

- Refactored helper functions (`_get_robot_image`, `_config_node_directory_exists`, `_delete_config_node_directory`) to use a cached image on the robot when running privileged containers, avoiding unnecessary Docker Hub pulls and improving reliability in restricted network environments. [[1]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acR47-R271) [[2]](diffhunk://#diff-678fb2d781870678e3c0bb9790f04a347658802dce071e5a59f1be52c1f211acL60-R291)

**Error handling and robustness:**

- Improved error handling in Docker login: API errors during login are now caught and logged, and the operation continues if `raise_on_error` is `False`, preventing abrupt failures in update workflows.
- Ensured proper cleanup: On update completion or interruption, the proxy configuration is restored and the `socat` process is terminated if it was started, preventing lingering processes or configuration.

These changes make the update process more robust and reliable, especially in environments where direct internet access is not available from the robot.