### PR TITLE
DTSW-7694-Add-the-ability-to-run-multiple-instances-of-the-Duckiematrix-on-a-single-machine

### DIFF
--- a/matrix/engine/run/command.py
+++ b/matrix/engine/run/command.py
@@ -25,6 +25,9 @@ MAX_RENDERERS = 4
 DEFAULT_STATIC_NETWORK_PORTS: Dict[str, int] = {
     "world-control-out-port": 7501,
     "matrix-control-out-port": 7502,
+    "matrix-websocket-bridge-control-out-port": 7503,
+    "matrix-websocket-bridge-data-out-port": 7504,
+    "matrix-websocket-bridge-data-in-port": 7505,
     "matrix-data-out-port": 17510,
     "matrix-data-in-port": 17511,
     "world-data-out-port": 17512,
@@ -96,6 +99,22 @@ class MatrixEngine:
             registry=docker_registry,
             distro=shell.profile.distro.name
         )
+        # check if a default-named engine container already exists
+        engine_container_name: str = parsed.engine_name if parsed.engine_name else "dts-matrix-engine"
+        if not parsed.engine_name:
+            docker = get_client_OLD()
+            existing = [
+                c for c in docker.containers.list(all=True, filters={"name": "dts-matrix-engine"})
+                if c.name == "dts-matrix-engine"
+            ]
+            if existing:
+                dtslogger.error(
+                    "A Duckiematrix engine container named 'dts-matrix-engine' already exists.\n"
+                    "To launch a second instance, provide an explicit name and port offset, e.g.:\n"
+                    "  --engine-name dts-matrix-engine-1 --port-offset 10\n"
+                    "Adjust the port offset as needed to avoid conflicts."
+                )
+                return False
         # engine container configuration
         engine_config = {
             "image": engine_image,
@@ -109,7 +128,7 @@ class MatrixEngine:
                 "IMPERSONATE_GID": os.getgid(),
             },
             "ports": {},
-            "name": "dts-matrix-engine"
+            "name": engine_container_name
         }
         engine_config.update(DUCKIEMATRIX_ENGINE_IMAGE_CONFIG)
         # set the mode
@@ -151,6 +170,9 @@ class MatrixEngine:
         # configure ports
         expose_ports: bool = parsed.expose_ports or platform.system() == "Darwin"
         static_ports: bool = parsed.static_ports
+        port_offset: int = parsed.port_offset
+        if port_offset:
+            static_ports = True
         # expose ports defined in the connector_ports layer + static ports
         if expose_ports or static_ports:
             connector_ports: Dict[str, int] = {}
@@ -169,6 +191,7 @@ class MatrixEngine:
                     connector_ports[name] = port
             # add ports to the engine configuration
             for name, port in connector_ports.items():
+                port += port_offset
                 # expose port to the host
                 if expose_ports:
                     engine_config["ports"][f"{port}/tcp"] = port

--- a/matrix/engine/run/configuration.py
+++ b/matrix/engine/run/configuration.py
@@ -88,6 +88,18 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Assign default values to all the ports"
         )
         parser.add_argument(
+            "--engine-name",
+            default=None,
+            type=str,
+            help="Name for the engine Docker container (default: dts-matrix-engine)"
+        )
+        parser.add_argument(
+            "--port-offset",
+            default=0,
+            type=int,
+            help="Offset to apply to all engine ports (useful for running multiple engines)"
+        )
+        parser.add_argument(
             "-vv",
             "--verbose",
             default=False,

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -50,6 +50,12 @@ class DTCommand(DTCommandAbs):
             help="Run both engine and renderer"
         )
         parser.add_argument(
+            "--engine-name",
+            default=None,
+            type=str,
+            help="Name for the engine Docker container (default: dts-matrix-engine)"
+        )
+        parser.add_argument(
             "-m",
             "--map",
             default=None,
@@ -69,6 +75,26 @@ class DTCommand(DTCommandAbs):
             default=None,
             type=str,
             help="Hostname or IP address of the engine to connect to"
+        )
+        parser.add_argument(
+            "-ep",
+            "--engine-control-port",
+            default=None,
+            type=int,
+            help="Control port of the engine to connect to (default: 7502)"
+        )
+        parser.add_argument(
+            "-ewp",
+            "--engine-ws-control-port",
+            default=None,
+            type=int,
+            help="WebSocket control port of the engine to connect to (default: 7503, WebGL only)"
+        )
+        parser.add_argument(
+            "--port-offset",
+            default=0,
+            type=int,
+            help="Port offset applied to the engine (sets -ep and -ewp automatically)"
         )
         parser.add_argument(
             "-r",
@@ -298,6 +324,12 @@ class DTCommand(DTCommandAbs):
             # custom engine
             if parsed.engine_hostname is not None:
                 app_config += ["--engine-hostname", parsed.engine_hostname]
+            _ep = parsed.engine_control_port if parsed.engine_control_port is not None else (7502 + parsed.port_offset if parsed.port_offset else None)
+            _ewp = parsed.engine_ws_control_port if parsed.engine_ws_control_port is not None else (7503 + parsed.port_offset if parsed.port_offset else None)
+            if _ep is not None:
+                app_config += ["--engine-control-port", str(_ep)]
+            if _ewp is not None:
+                app_config += ["--engine-ws-control-port", str(_ewp)]
             # custom renderer ID
             if parsed.renderer_id is not None:
                 app_config += ["--renderer-id", f"renderer_{parsed.renderer_id}"]
@@ -375,6 +407,12 @@ class DTCommand(DTCommandAbs):
                         url += f"renderer-key={parsed.renderer_key}&"
                     if parsed.engine_hostname is not None:
                         url += f"engine-hostname={parsed.engine_hostname}&"
+                    _ep = parsed.engine_control_port if parsed.engine_control_port is not None else (7502 + parsed.port_offset if parsed.port_offset else None)
+                    _ewp = parsed.engine_ws_control_port if parsed.engine_ws_control_port is not None else (7503 + parsed.port_offset if parsed.port_offset else None)
+                    if _ep is not None:
+                        url += f"engine-control-port={_ep}&"
+                    if _ewp is not None:
+                        url += f"engine-ws-control-port={_ewp}&"
                     url += f"profiler={'true' if parsed.profiler else 'false'}&"
                     url += f"tutorial={'true' if not parsed.no_tutorial else 'false'}&"
                     url += f"token={shell.profile.secrets.dt_token}/"


### PR DESCRIPTION
This pull request introduces enhanced configurability for engine networking and container naming in the Matrix engine and client. The main improvements allow users to specify custom engine container names, apply port offsets for running multiple engines concurrently, and explicitly set engine control ports from the command line. These changes make it easier to manage multiple engine instances and avoid port conflicts.

**Engine configuration enhancements:**

* Added support for specifying a custom engine container name via the `--engine-name` argument in `matrix/engine/run/configuration.py` and used it in engine configuration (`matrix/engine/run/command.py`). [[1]](diffhunk://#diff-0b281844232a646fab546d2a57f5d407a51cc23b423eff8a342696f6a835d4cfR90-R101) [[2]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baL112-R115)
* Introduced a `--port-offset` argument to apply an offset to all engine ports, ensuring unique port assignments when running multiple engines. The offset is applied in port assignment logic. [[1]](diffhunk://#diff-0b281844232a646fab546d2a57f5d407a51cc23b423eff8a342696f6a835d4cfR90-R101) [[2]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baR157-R159) [[3]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baR178)

**Static and connector port updates:**

* Added new static network ports for the matrix websocket bridge to the `DEFAULT_STATIC_NETWORK_PORTS` dictionary.

**Client-side port and connection configuration:**

* Added command-line arguments (`-ep`, `--engine-control-port` and `-ewp`, `--engine-ws-control-port`) in `matrix/run/command.py` to allow explicit specification of control ports, and a `--port-offset` argument to adjust these automatically.
* Updated the command and URL construction logic to use the specified or offset ports for engine connections, ensuring the correct ports are passed and encoded in URLs. [[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR321-R326) [[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR404-R409)