### PR TITLE
DTSW-7700-macos-bug-when-launching-the-duckiematrix

### DIFF
--- a/duckiebot/virtual/create/command.py
+++ b/duckiebot/virtual/create/command.py
@@ -20,7 +20,6 @@ from utils.duckietown_utils import get_robot_types, get_robot_configurations, US
 from utils.misc_utils import pretty_json, pretty_exc
 from ..destroy.command import DTCommand as DestroyVirtualDuckiebotCommand
 
-DEVICE_ARCH = get_endpoint_architecture()
 DISK_NAME = "root"
 DIND_IMAGE_NAME = "docker:24.0-dind"
 VIRTUAL_FLEET_DIR = os.path.join(USER_DATA_DIR, "virtual_robots")
@@ -67,6 +66,8 @@ class DTCommand(DTCommandAbs):
             return
         # get registry
         registry_to_use: str = get_registry_to_use()
+        # get local architecture (deferred from module level to avoid Docker socket access at import time)
+        device_arch: str = get_endpoint_architecture()
         # get the robot configuration
         allowed_configs = get_robot_configurations(parsed.type)
         if parsed.configuration is None:
@@ -122,9 +123,9 @@ class DTCommand(DTCommandAbs):
                 run_cmd(["cp", origin, destination])
                 # add architecture as default value in the stack file
                 dtslogger.debug(
-                    "- Replacing '{ARCH}' with '{ARCH:-%s}' in %s" % (DEVICE_ARCH, destination)
+                    "- Replacing '{ARCH}' with '{ARCH:-%s}' in %s" % (device_arch, destination)
                 )
-                replace_in_file("{ARCH}", "{ARCH:-%s}" % DEVICE_ARCH, destination, open)
+                replace_in_file("{ARCH}", "{ARCH:-%s}" % device_arch, destination, open)
                 # add registry as default value in the stack file
                 dtslogger.debug(
                     "- Replacing '{REGISTRY}' with '{REGISTRY:-%s}' in %s" % (registry_to_use, destination)
@@ -188,7 +189,7 @@ class DTCommand(DTCommandAbs):
                         module=module["module"],
                         version=distro,
                         tag=module["tag"] if "tag" in module else None,
-                        arch=DEVICE_ARCH,
+                        arch=device_arch,
                         registry=module.get("registry", registry_to_use)
                     )
                     pull_docker_image(remote_docker, image)

--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -11,9 +11,8 @@ from utils.misc_utils import pretty_yaml
 from utils.docker_utils import get_endpoint_architecture
 
 DISK_NAME = "root"
-DEVICE_ARCH = get_endpoint_architecture()
 VIRTUAL_FLEET_DIR = os.path.join(USER_DATA_DIR, "virtual_robots")
-VIRTUAL_ROBOT_RUNTIME_IMAGE = "duckietown/dt-virtual-device:{distro}-%s" % DEVICE_ARCH
+VIRTUAL_ROBOT_RUNTIME_IMAGE = "duckietown/dt-virtual-device:{distro}-{arch}"
 
 
 class DTCommand(DTCommandAbs):
@@ -65,7 +64,7 @@ class DTCommand(DTCommandAbs):
             # good
             pass
         # launch robot
-        runtime_image = VIRTUAL_ROBOT_RUNTIME_IMAGE.format(distro=parsed.tag)
+        runtime_image = VIRTUAL_ROBOT_RUNTIME_IMAGE.format(distro=parsed.tag, arch=get_endpoint_architecture())
         if parsed.pull:
             dtslogger.info("Downloading virtual robot runtime...")
             # pull dind image

--- a/matrix/engine/run/command.py
+++ b/matrix/engine/run/command.py
@@ -15,8 +15,7 @@ from utils.docker_utils import DEFAULT_REGISTRY, get_client_OLD, pull_image_OLD,
 from utils.duckiematrix_utils import \
     APP_NAME
 
-DEVICE_ARCH = get_endpoint_architecture()
-DUCKIEMATRIX_ENGINE_IMAGE_FMT = "{registry}/duckietown/dt-duckiematrix:{distro}-%s" % DEVICE_ARCH
+DUCKIEMATRIX_ENGINE_IMAGE_FMT = "{registry}/duckietown/dt-duckiematrix:{distro}-{arch}"
 EXTERNAL_SHUTDOWN_REQUEST = "===REQUESTED-EXTERNAL-SHUTDOWN==="
 
 DUCKIEMATRIX_ENGINE_IMAGE_CONFIG = {}
@@ -94,7 +93,8 @@ class MatrixEngine:
         # compile engine image name
         engine_image = DUCKIEMATRIX_ENGINE_IMAGE_FMT.format(
             registry=docker_registry,
-            distro=shell.profile.distro.name
+            distro=shell.profile.distro.name,
+            arch=get_endpoint_architecture()
         )
         # engine container configuration
         engine_config = {


### PR DESCRIPTION
This pull request refactors how the device architecture is determined and used in the `duckiebot/virtual` and `matrix/engine` modules. The main improvement is to defer the call to `get_endpoint_architecture()` from module load time to runtime, ensuring that Docker socket access does not occur during import, which improves robustness and flexibility. Several image naming patterns are also updated to accept the architecture as a format parameter.

**Refactoring device architecture handling:**

* Moved the call to `get_endpoint_architecture()` from module-level scope to inside functions at runtime in `duckiebot/virtual/create/command.py`, `duckiebot/virtual/start/command.py`, and `matrix/engine/run/command.py` to avoid Docker socket access at import time. [[1]](diffhunk://#diff-4a33f82b695d0dc0dd566c29bcc9a4ad475a06b0302840d421198d900728f35dL23) [[2]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L14-R15) [[3]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baL18-R18)
* Updated references from the old `DEVICE_ARCH` variable to the new runtime-local `device_arch` or inline call to `get_endpoint_architecture()` throughout the command logic. [[1]](diffhunk://#diff-4a33f82b695d0dc0dd566c29bcc9a4ad475a06b0302840d421198d900728f35dR69-R70) [[2]](diffhunk://#diff-4a33f82b695d0dc0dd566c29bcc9a4ad475a06b0302840d421198d900728f35dL125-R128) [[3]](diffhunk://#diff-4a33f82b695d0dc0dd566c29bcc9a4ad475a06b0302840d421198d900728f35dL191-R192) [[4]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L68-R67) [[5]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baL97-R97)

**Image naming improvements:**

* Changed image format strings (e.g., `VIRTUAL_ROBOT_RUNTIME_IMAGE`, `DUCKIEMATRIX_ENGINE_IMAGE_FMT`) to use an `{arch}` placeholder instead of hardcoding the architecture at import time, allowing for dynamic substitution at runtime. [[1]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L14-R15) [[2]](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baL18-R18)

These changes make the codebase more robust to different runtime environments and prevent issues related to premature Docker socket access.