### PR TITLE
fix/DTSW-7778-publish-rosbridge-port-9001

### DIFF
--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -100,7 +100,7 @@ class DTCommand(DTCommandAbs):
                 ["14551", "14551", "udp"],   # Ardupilot SITL
                 ["7447", "7447", "tcp"],     # ROS2 zenoh bridge
                 ["8080", "8080", "tcp"],     # Dashboard (HTTP)
-                ["9090", "9090", "tcp"],     # rosbridge WebSocket
+                ["9001", "9001", "tcp"],     # rosbridge WebSocket
             ],
             "volumes": [
                 # Keep var/lib/docker as bind mount for Docker daemon data


### PR DESCRIPTION
The rosbridge-websocket container inside the virtual-drone DinD actually listens on 9001 (per the ros package schema default); 9090 was a guess and nothing binds to it, so the prior mapping did nothing useful. Swap the publish so the dashboard widgets can reach rosbridge from outside the devcontainer.