### PR TITLE
feat(ros2/duckiedrone): wire Raspberry Pi camera into stack (DTSW-7758)

### DIFF
--- a/stack/stacks/ros2/duckiedrone.yaml
+++ b/stack/stacks/ros2/duckiedrone.yaml
@@ -15,15 +15,16 @@ services:
     container_name: ros2-camera
     restart: unless-stopped
     network_mode: host
-    pid: host
+    privileged: true
     security_opt:
       - seccomp=unconfined
     environment:
-      DT_LAUNCHER: sensor-camera
+      DT_LAUNCHER: sensor-camera-rpi
       DT_SUPERUSER: 1
       ROS_DOMAIN_ID: 42
     volumes:
-      - /data/ramdisk/dtps:/dtps
+      - /dev:/dev
+      - /run/udev:/run/udev:ro
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
     depends_on:


### PR DESCRIPTION
## Summary

- Point the `camera` service at the new `sensor-camera-rpi` launcher added in duckietown/dt-ros2-interface#14
- Swap `pid: host` + the `/dtps` ramdisk mount (DTPS-specific) for `privileged: true` + `/dev:/dev` + `/run/udev:/run/udev:ro` so libcamera/picamera2 can discover and open the OV5647 CSI sensor

## Test plan

- [x] Verified the resulting container publishes `/drone01/image/compressed` @ 30 Hz and `/drone01/camera_info` @ 30 Hz on `drone01` (DD24)
- [x] Stream visible via `foxglove_bridge` from a laptop on the same network

Requires: duckietown/dt-ros2-interface#14 (provides the launcher + driver this stack references)

Jira: DTSW-7758