### PR TITLE
DTSW-7795-Add-a-no-pull-option-to-the-Duckietown-Viewer-commands

### DIFF
--- a/duckiebot/calibrate_extrinsics/command.py
+++ b/duckiebot/calibrate_extrinsics/command.py
@@ -29,6 +29,7 @@ class DTCommand(DTCommandAbs):
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
             browser=browser,
+            no_pull=parsed.no_pull,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/calibrate_extrinsics/configuration.py
+++ b/duckiebot/calibrate_extrinsics/configuration.py
@@ -58,6 +58,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Run in browser mode"
         )
         parser.add_argument(
+            "--no-pull",
+            default=False,
+            action="store_true",
+            help="Do not attempt to update the backend container image"
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default="",

--- a/duckiebot/calibrate_intrinsics/command.py
+++ b/duckiebot/calibrate_intrinsics/command.py
@@ -29,6 +29,7 @@ class DTCommand(DTCommandAbs):
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
             browser=browser,
+            no_pull=parsed.no_pull,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/calibrate_intrinsics/configuration.py
+++ b/duckiebot/calibrate_intrinsics/configuration.py
@@ -58,6 +58,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Run in browser mode"
         )
         parser.add_argument(
+            "--no-pull",
+            default=False,
+            action="store_true",
+            help="Do not attempt to update the backend container image"
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default="",

--- a/duckiebot/image_viewer/command.py
+++ b/duckiebot/image_viewer/command.py
@@ -29,6 +29,7 @@ class DTCommand(DTCommandAbs):
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
             browser=browser,
+            no_pull=parsed.no_pull,
             window_args={
                 "height": 634,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/image_viewer/configuration.py
+++ b/duckiebot/image_viewer/configuration.py
@@ -58,6 +58,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Run in browser mode"
         )
         parser.add_argument(
+            "--no-pull",
+            default=False,
+            action="store_true",
+            help="Do not attempt to update the backend container image"
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default="",

--- a/duckiebot/keyboard_control/command.py
+++ b/duckiebot/keyboard_control/command.py
@@ -33,6 +33,7 @@ class DTCommand(DTCommandAbs):
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
             browser=browser,
+            no_pull=parsed.no_pull,
             window_args={
                 "height": 418,
                 "icon": get_asset_icon_path(ICON_ASSET),

--- a/duckiebot/keyboard_control/configuration.py
+++ b/duckiebot/keyboard_control/configuration.py
@@ -54,6 +54,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Run in browser mode"
         )
         parser.add_argument(
+            "--no-pull",
+            default=False,
+            action="store_true",
+            help="Do not attempt to update the backend container image"
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default="",

--- a/duckiebot/led_control/command.py
+++ b/duckiebot/led_control/command.py
@@ -29,6 +29,7 @@ class DTCommand(DTCommandAbs):
             on_top=parsed.on_top,
             enable_hardware_acceleration=parsed.enable_hardware_acceleration,
             browser=browser,
+            no_pull=parsed.no_pull,
             window_args={
                 "icon": get_asset_icon_path(ICON_ASSET),
                 "min-height": 600,

--- a/duckiebot/led_control/configuration.py
+++ b/duckiebot/led_control/configuration.py
@@ -58,6 +58,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Run in browser mode"
         )
         parser.add_argument(
+            "--no-pull",
+            default=False,
+            action="store_true",
+            help="Do not attempt to update the backend container image"
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default="",

--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -15,12 +15,12 @@ import requests
 import webbrowser
 from dockertown import Container
 from dockertown import DockerClient
-from dockertown.exceptions import NoSuchContainer
+from dockertown.exceptions import NoSuchContainer, NoSuchImage
 from dt_data_api import DataClient
 
 import dt_shell
 from dt_shell import dtslogger, DTShell, UserError
-from utils.docker_utils import get_client, get_registry_to_use, pull_image
+from utils.docker_utils import get_client, get_endpoint_architecture, get_registry_to_use, pull_image
 from utils.duckietown_utils import USER_DATA_DIR, get_distro
 from utils.misc_utils import versiontuple, random_string
 from utils.networking_utils import get_duckiebot_ip
@@ -443,8 +443,20 @@ def ensure_duckietown_viewer_installed(os_family: str = "", log_prefix: str = ""
     dtslogger.info(f"{log_prefix}Installation completed successfully!")
 
 
-def launch_viewer(app: str, *, os_family: str = "", robot: Optional[str] = None, verbose: bool = False, fullscreen: bool = False, menu: bool = False, on_top: bool = False, enable_hardware_acceleration: bool = False, browser: bool = False, window_args: Optional[WindowArgs] = None) \
-        -> 'DuckietownViewerInstance':
+def launch_viewer(
+    app: str,
+    *,
+    os_family: str = "",
+    robot: Optional[str] = None,
+    verbose: bool = False,
+    fullscreen: bool = False,
+    menu: bool = False,
+    on_top: bool = False,
+    enable_hardware_acceleration: bool = False,
+    browser: bool = False,
+    no_pull: bool = False,
+    window_args: Optional[WindowArgs] = None
+) -> 'DuckietownViewerInstance':
     """Create and start a :class:`DuckietownViewerInstance`.
 
     This is a convenience wrapper that instantiates the viewer, calls
@@ -464,6 +476,7 @@ def launch_viewer(app: str, *, os_family: str = "", robot: Optional[str] = None,
             viewer.
         browser: Open the viewer URL in the system browser instead of the
             native app window.
+        no_pull: Use a local backend image without pulling updates.
         window_args: Extra keyword arguments forwarded to the frontend binary
             as ``--key=value`` CLI flags.  A ``"url"`` key bypasses the
             backend entirely.
@@ -472,7 +485,17 @@ def launch_viewer(app: str, *, os_family: str = "", robot: Optional[str] = None,
         The :class:`DuckietownViewerInstance` after it has finished running.
     """
     viewer = DuckietownViewerInstance(os_family, verbose)
-    viewer.start(app, robot, fullscreen, menu, on_top, enable_hardware_acceleration, browser, window_args=window_args)
+    viewer.start(
+        app=app,
+        robot=robot,
+        fullscreen=fullscreen,
+        menu=menu,
+        on_top=on_top,
+        enable_hardware_acceleration=enable_hardware_acceleration,
+        browser=browser,
+        no_pull=no_pull,
+        window_args=window_args,
+    )
     return viewer
 
 
@@ -519,7 +542,54 @@ class DuckietownViewerInstance:
         self._frontend: Optional[subprocess.Popen] = None
         self._backend_url: Optional[str] = None
 
-    def start(self, app: str, robot: Optional[str], fullscreen: Optional[bool], menu: Optional[bool], on_top: Optional[bool], enable_hardware_acceleration: Optional[bool], browser: bool = False, window_args: Optional[WindowArgs] = None):
+    @classmethod
+    def _local_arch_image(cls, image: str, docker: DockerClient) -> Optional[str]:
+        """Return the local architecture-specific image tag when it exists."""
+        try:
+            arch = get_endpoint_architecture()
+        except Exception:
+            dtslogger.debug("Could not determine Docker endpoint architecture.")
+            return None
+
+        local_image = f"{image}-{arch}"
+        try:
+            docker.image.inspect(local_image)
+        except NoSuchImage:
+            return None
+        return local_image
+
+    @classmethod
+    def _backend_image(cls, docker: DockerClient, no_pull: bool = False) -> str:
+        """Resolve the backend image, optionally using a local development build."""
+        image = cls._BACKEND_DOCKER_IMAGE.format(
+            registry=get_registry_to_use(),
+            distro=get_distro(dt_shell.shell).name
+        )
+        if no_pull:
+            local_image = cls._local_arch_image(image, docker)
+            if local_image is None:
+                raise UserError(
+                    f"No local viewer backend image found for '{image}'. "
+                    "Run 'dts devel build' in dt-duckietown-viewer or omit '--no-pull'."
+                )
+            return local_image
+
+        dtslogger.info("Checking for updates...")
+        pull_image(image, docker)
+        return image
+
+    def start(
+        self,
+        app: str,
+        robot: Optional[str],
+        fullscreen: Optional[bool],
+        menu: Optional[bool],
+        on_top: Optional[bool],
+        enable_hardware_acceleration: Optional[bool],
+        browser: bool = False,
+        no_pull: bool = False,
+        window_args: Optional[WindowArgs] = None
+    ):
         """Start the viewer backend (if needed) and then the frontend, blocking until exit.
 
         If *window_args* contains a ``"url"`` key the backend is skipped and
@@ -535,10 +605,11 @@ class DuckietownViewerInstance:
             enable_hardware_acceleration: Pass ``--enable-hardware-acceleration``
                 to the frontend.
             browser: Open in the system browser instead of the native app.
+            no_pull: Use a local backend image without pulling updates.
             window_args: Additional ``--key=value`` arguments for the frontend.
         """
         if "url" not in window_args.keys():
-            self._start_backend(app, robot)
+            self._start_backend(app, robot, no_pull)
             if not self._wait_backend_ready():
                 self._backend.stop()
                 return
@@ -557,7 +628,7 @@ class DuckietownViewerInstance:
             self._join_frontend()
         self._stop()
 
-    def _start_backend(self, app: str, robot: str):
+    def _start_backend(self, app: str, robot: str, no_pull: bool = False):
         """Pull the backend Docker image and start a container for the given app.
 
         The container exposes the backend HTTP server on a random host port.
@@ -568,6 +639,7 @@ class DuckietownViewerInstance:
         Args:
             app: The viewer app identifier (must be in :attr:`_KNOWN_APPS`).
             robot: Hostname or IP of the robot to connect to.
+            no_pull: Use a local backend image without pulling updates.
 
         Raises:
             ValueError: If *app* is not in :attr:`_KNOWN_APPS`.
@@ -586,12 +658,7 @@ class DuckietownViewerInstance:
         # create docker client
         docker: DockerClient = get_client()
         # compile image name
-        image = self._BACKEND_DOCKER_IMAGE.format(
-            registry=get_registry_to_use(),
-            distro=get_distro(dt_shell.shell).name
-        )
-        dtslogger.info(f"Checking for updates...")
-        pull_image(image, docker)
+        image = self._backend_image(docker, no_pull)
         dtslogger.debug(f"Using image '{image}'")
         # create container
         container_name: str = f"duckietown-viewer-backend-{random_string()}"


### PR DESCRIPTION
This pull request introduces a new `--no-pull` command-line option to several Duckiebot viewer-related commands, allowing users to skip pulling backend container image updates and use a local image instead. The implementation includes updates to the configuration parsers, command invocation, and viewer backend startup logic to support this feature.

The most important changes are:

**New Feature: `--no-pull` Option**

* Added a `--no-pull` argument to the command-line parsers in `configuration.py` for `calibrate_extrinsics`, `calibrate_intrinsics`, `image_viewer`, `keyboard_control`, and `led_control`, allowing users to prevent updating the backend container image. [[1]](diffhunk://#diff-29ec1ccac97f8a17602434b417717a14ab9902271954d64c609a05a77652689aR60-R65) [[2]](diffhunk://#diff-3a841b3192eaec6f6870069a20d420865b4d8e00a564396a6efbfea2109facd9R60-R65) [[3]](diffhunk://#diff-96ac15fded4bfe1d72c33acef6378e281bb40349ab16d173809d11aa55ea93b3R60-R65) [[4]](diffhunk://#diff-9c65bf1bcf0b5cc10af759ba2f024e17089c99a13173a16363c80be98d346d93R56-R61) [[5]](diffhunk://#diff-bc8c02f77f5960bac256a7403050f38bf06c2d17b1023cfde5fec17021556422R60-R65)

* Updated the corresponding `command.py` files to pass the `no_pull` option through to the viewer launch logic. [[1]](diffhunk://#diff-5bc8b4ec232c7b5ff2aa3f27c877bdfc3d0575afb3d521aab742512e92911bf1R32) [[2]](diffhunk://#diff-951e5944015e11c7c1b448152336602675d9180d863cd93f3080af4503366648R32) [[3]](diffhunk://#diff-95d2b4e8fa0f01366acce226de332a0b4ede549f5f6967dfd2a7724c4731c721R32) [[4]](diffhunk://#diff-a5093827d0486a87c42434637b3d893d32308d45b55bd4f02cb4b3cc70b0c552R36) [[5]](diffhunk://#diff-ac53a6a078c53da505b263173e7be27fc91460952d769b54e84e35d7d492d670R32)

**Viewer Backend Logic Enhancements**

* Refactored `utils/duckietown_viewer_utils.py`:
    - Updated the `launch_viewer` and `DuckietownViewerInstance.start` methods to accept and propagate the `no_pull` argument. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL446-R459) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eR479) [[3]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL475-R498) [[4]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eR608-R612)
    - Added logic to resolve and use a local backend image if `no_pull` is set, including helper methods `_local_arch_image` and `_backend_image`. Raises an error if no local image is found and `--no-pull` is used. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL522-R592) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL589-R661)
    - Modified backend startup to respect the `no_pull` option throughout the launch process. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL560-R631) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eR642) [[3]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL589-R661)

**Dependency and Import Updates**

* Updated imports in `utils/duckietown_viewer_utils.py` to include `NoSuchImage` and `get_endpoint_architecture` for the new backend image logic.

These changes collectively provide more flexibility for developers and advanced users who want to use locally built backend images without pulling updates from the registry.