### PR TITLE
DTSW-7797-Add-extra-ports-to-the-virtual-robot-start-command

### DIFF
--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -98,9 +98,12 @@ class DTCommand(DTCommandAbs):
             "cgroupns": "private",
             "publish": [
                 ["14551", "14551", "udp"],   # Ardupilot SITL
+                ["80", "80", "tcp"],         # device-proxy HTTP entrypoint for robot.local/dashboard/... 
                 ["7447", "7447", "tcp"],     # ROS2 zenoh bridge
-                ["8080", "8080", "tcp"],     # Dashboard (HTTP)
+                ["8080", "8080", "tcp"],     # Dashboard backend (HTTP)
                 ["9001", "9001", "tcp"],     # rosbridge WebSocket
+                ["11411", "11411", "tcp"],   # DTPS KV store
+                ["11911", "11911", "tcp"],   # DTPS switchboard
             ],
             "volumes": [
                 # Keep var/lib/docker as bind mount for Docker daemon data


### PR DESCRIPTION
This pull request updates the port publishing configuration for the Duckiebot virtual environment, primarily to support additional services and clarify existing ones. The main changes are the addition of new port mappings for internal services and improved comments for clarity.

**Network and Service Configuration Updates:**

* Added port `80/tcp` for the `device-proxy` HTTP entrypoint, enabling access to `robot.local/dashboard/...`.
* Added ports `11411/tcp` and `11911/tcp` for DTPS KVStore and DTPS switchboard services, respectively, supporting new internal services.
* Updated the comment for the `8080/tcp` port to clarify that it is used for the Dashboard backend (HTTP).