### PR TITLE
DTSW-7808-Add-the-ability-to-open-multiple-Duckietown-Viewer-apps-on-macOS

### DIFF
--- a/utils/duckietown_viewer_utils.py
+++ b/utils/duckietown_viewer_utils.py
@@ -795,7 +795,7 @@ class DuckietownViewerInstance:
         Builds the CLI argument list from the supplied options, resolves the
         platform-specific binary path, and spawns the process with
         :class:`subprocess.Popen`.  On macOS ``.app`` bundles are launched via
-        ``open -W``.
+        ``open -n -W``.
 
         Args:
             fullscreen: Pass ``--fullscreen`` to the binary.
@@ -832,8 +832,8 @@ class DuckietownViewerInstance:
         dtslogger.info("Launching viewer...")
         # On macOS, use 'open' command for .app bundles
         if (os_family == "macos" or os_family == "macos-arm64") and app_bin.endswith(".app"):
-            # -W flag makes open wait until the application exits
-            app_cmd = ["open", "-W", app_bin, "--args"] + app_config
+            # -n starts a separate app instance; -W waits until that instance exits.
+            app_cmd = ["open", "-n", "-W", app_bin, "--args"] + app_config
         else:
             app_cmd = [app_bin] + app_config
         dtslogger.debug(f"$ > {app_cmd}")


### PR DESCRIPTION
This pull request updates the way the viewer frontend is launched on macOS systems. The main improvement is ensuring that each launch starts a new, separate instance of the application, rather than reusing an existing one.

macOS application launch changes:

* In the `_start_frontend` method in `utils/duckietown_viewer_utils.py`, the `open` command now includes the `-n` flag in addition to `-W` when launching `.app` bundles. This ensures a new instance of the app is started each time, and the process waits until that instance exits. [[1]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL798-R798) [[2]](diffhunk://#diff-5bce7a9bb41317c0b80a72f1037c145c1b5327990f673c61450834448afc359eL835-R836)