### PR TITLE
DTSW-7811-Fix-virtual-robot-startup

### DIFF
--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -31,6 +31,13 @@ class DTCommand(DTCommandAbs):
             help="Do not update the runtime image"
         )
         parser.add_argument(
+            "--pull",
+            action='store_true',
+            default=False,
+            dest="deprecated_pull",
+            help=argparse.SUPPRESS
+        )
+        parser.add_argument(
             "-t",
             "--tag",
             type=str,
@@ -40,6 +47,10 @@ class DTCommand(DTCommandAbs):
         parser.add_argument("robot", nargs=1, help="Name of the Robot to start")
         # parse arguments
         parsed = parser.parse_args(args)
+        if parsed.deprecated_pull:
+            dtslogger.warning("The '--pull' option is deprecated and no longer needed; "
+                              "the runtime image is updated by default. "
+                              "Use '--no-pull' to skip the update.")
         # sanitize arguments
         parsed.robot = parsed.robot[0]
         # make sure the virtual robot exists

--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -25,10 +25,10 @@ class DTCommand(DTCommandAbs):
         parser = argparse.ArgumentParser(prog=prog)
         # define arguments
         parser.add_argument(
-            "--pull",
+            "--no-pull",
             action='store_true',
             default=False,
-            help="Update the runtime image"
+            help="Do not update the runtime image"
         )
         parser.add_argument(
             "-t",
@@ -65,9 +65,8 @@ class DTCommand(DTCommandAbs):
             pass
         # launch robot
         runtime_image = VIRTUAL_ROBOT_RUNTIME_IMAGE.format(distro=parsed.tag, arch=get_endpoint_architecture())
-        if parsed.pull:
+        if not parsed.no_pull:
             dtslogger.info("Downloading virtual robot runtime...")
-            # pull dind image
             pull_docker_image(local_docker, runtime_image)
         # create named volumes for each directory
         volumes = []


### PR DESCRIPTION
This pull request updates the behavior and naming of the runtime image update flag in the `duckiebot/virtual/start/command.py` script. The main change is to switch from a `--pull` flag (which previously triggered an image update) to a `--no-pull` flag (which now skips the image update by default, unless specified).

**Flag renaming and logic update:**

* Changed the command-line argument from `--pull` to `--no-pull` to invert the logic, making the default behavior to update the runtime image unless `--no-pull` is specified. Updated the help text accordingly.
* Updated the conditional logic to match the new flag: the runtime image is pulled unless `--no-pull` is set.