### PR TITLE
DTSW-7813-Fix-Duckiematrix-Renderer-behaviour-on-macOS

### DIFF
--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -1,8 +1,10 @@
 import json
 import os
+import plistlib
 import time
 from collections import Counter
 from pathlib import Path
+from plistlib import InvalidFileException
 
 import subprocess
 import platform
@@ -10,6 +12,7 @@ import socket
 import webbrowser
 from socket import AF_INET, SOCK_STREAM
 from http.server import HTTPServer, SimpleHTTPRequestHandler
+from subprocess import TimeoutExpired
 from threading import Thread
 from typing import Optional, Callable
 
@@ -111,9 +114,9 @@ class DTCommand(DTCommandAbs):
                 return
             # app configuration
             app_path = get_path_to_app(os_family, version, browser)
-            # Unity on Windows/WSL uses "-" to mean "log to stdout"; "/dev/stdout" only exists on Unix-like OSes.
+            # Unity on macOS/Windows uses "-" to mean "log to stdout"; "/dev/stdout" works on Linux.
             app_config = [
-                "-logfile", "-" if os_family == "windows" else "/dev/stdout"
+                "-logfile", "/dev/stdout" if os_family == "linux" else "-"
             ]
             # graphics API
             if parsed.force_opengl:
@@ -246,7 +249,15 @@ class DTCommand(DTCommandAbs):
                 else:
                     # run the app
                     dtslogger.info("Launching Renderer...")
-                    app_path_list = ["open", app_path, "--args"] if os_family == "macos" else [app_path]
+                    if os_family == "macos":
+                        try:
+                            app_path_list = [get_macos_app_executable(app_path)]
+                        except FileNotFoundError as error:
+                            error_string = str(error)
+                            dtslogger.error(error_string)
+                            return
+                    else:
+                        app_path_list = [app_path]
                     app_cmd = app_path_list + app_config
                     dtslogger.debug(f"$ > {app_cmd}")
                     time.sleep(2)
@@ -293,6 +304,26 @@ def join_renderer(process: subprocess.Popen, verbose: bool = False):
         line = line.decode("utf-8")
         if EXTERNAL_SHUTDOWN_REQUEST in line:
             process.kill()
+            try:
+                process.wait(timeout=5)
+            except TimeoutExpired:
+                pass
             return
         if verbose:
             print(line, end="")
+
+
+def get_macos_app_executable(app_path: str) -> str:
+    app_bundle = Path(app_path)
+    info_plist = app_bundle / "Contents" / "Info.plist"
+    executable_name = app_bundle.stem
+    if info_plist.is_file():
+        try:
+            with info_plist.open("rb") as file:
+                executable_name = plistlib.load(file).get("CFBundleExecutable") or executable_name
+        except (OSError, InvalidFileException, ValueError):
+            pass
+    executable_path = app_bundle / "Contents" / "MacOS" / executable_name
+    if not executable_path.is_file():
+        raise FileNotFoundError(f"Could not find executable in macOS app bundle '{app_path}'.")
+    return str(executable_path)

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -116,9 +116,9 @@ class DTCommand(DTCommandAbs):
                 return
             # app configuration
             app_path = get_path_to_app(os_family, version, browser)
-            # Unity on Windows/WSL uses "-" to mean "log to stdout"; "/dev/stdout" only exists on Unix-like OSes.
+            # Unity on macOS/Windows uses "-" to mean "log to stdout"; "/dev/stdout" works on Linux.
             app_config = [
-                "-logfile", "-" if os_family == "windows" else "/dev/stdout"
+                "-logfile", "/dev/stdout" if os_family == "linux" else "-"
             ]
             # graphics API
             if parsed.force_opengl:
@@ -251,7 +251,7 @@ class DTCommand(DTCommandAbs):
                 else:
                     # run the app
                     dtslogger.info("Launching Renderer...")
-                    app_path_list = ["open", app_path, "--args"] if os_family == "macos" else [app_path]
+                    app_path_list = ["open", "-n", "-W", app_path, "--args"] if os_family == "macos" else [app_path]
                     app_cmd = app_path_list + app_config
                     if parsed.xvfb:
                         if os_family != "linux":


### PR DESCRIPTION
This pull request makes several improvements to how the application is launched, especially on macOS, and enhances process handling for renderer shutdown. The most notable changes are the addition of a helper function to reliably find the macOS app bundle executable, improved error handling, and a fix for log file output selection based on the operating system.

**macOS app launching and process handling improvements:**

* Added a new `get_macos_app_executable` function to robustly locate the executable inside a macOS `.app` bundle by reading the `Info.plist` file, and integrated this into the app launch logic. This ensures the correct executable is used and provides clear error messages if not found. [[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aL249-R260) [[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR307-R329)
* Changed the logic for setting the log file output: now uses `"/dev/stdout"` only on Linux and `"-"` on macOS/Windows, aligning with platform conventions and preventing errors on macOS.

**Process shutdown handling:**

* Improved shutdown of the renderer process by waiting for termination with a timeout after a kill signal, preventing lingering processes.

**Dependency and import updates:**

* Added imports for `plistlib`, `InvalidFileException`, and `TimeoutExpired` to support new functionality and error handling.