### PR TITLE
DTSW-7852-Provide-guidance-for-Linux-and-Windows-ARM-machines

### DIFF
--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 import shlex
+import errno
 from collections import Counter
 
 import subprocess
@@ -25,6 +26,17 @@ from utils.duckiematrix_utils import \
     get_os_family
 
 EXTERNAL_SHUTDOWN_REQUEST: str = "===REQUESTED-EXTERNAL-SHUTDOWN==="
+FEX_EXECUTABLES = ("FEX", "FEXInterpreter")
+ARM64_MACHINES = ("aarch64", "arm64")
+FEX_SETUP_GUIDANCE = (
+    "See https://fex-emu.com/ for setup instructions, or use --browser to avoid the "
+    "native renderer."
+)
+WINDOWS_ARM64_SETUP_GUIDANCE = (
+    "Windows on ARM64 can run x86-64 applications through Windows emulation. "
+    "If launch fails, verify x64 emulation support is available, or use --browser to avoid "
+    "the native renderer."
+)
 
 
 class DTCommand(DTCommandAbs):
@@ -81,6 +93,7 @@ class DTCommand(DTCommandAbs):
         # configure renderer
         app_path: Optional[str] = None
         app_config: list = []
+        app_prefix: list = []
         terminate_renderer: Optional[Callable] = None
         if run_renderer:
             os_family = parsed.os_family
@@ -116,6 +129,18 @@ class DTCommand(DTCommandAbs):
                 return
             # app configuration
             app_path = get_path_to_app(os_family, version, browser)
+            if not browser and should_run_linux_renderer_through_fex(os_family):
+                fex_executable = find_fex_executable()
+                if fex_executable is None:
+                    message = format_fex_renderer_message()
+                    dtslogger.error(message)
+                    return
+                app_prefix = [fex_executable]
+            elif not browser and is_arm64_windows_host(os_family):
+                dtslogger.info(
+                    "Detected an ARM64 Windows host. The Windows Duckiematrix renderer "
+                    "is an x86-64 binary and will rely on Windows x64 emulation."
+                )
             # Unity on macOS/Windows uses "-" to mean "log to stdout"; "/dev/stdout" works on Linux.
             app_config = [
                 "-logfile", "/dev/stdout" if os_family == "linux" else "-"
@@ -251,7 +276,7 @@ class DTCommand(DTCommandAbs):
                 else:
                     # run the app
                     dtslogger.info("Launching Renderer...")
-                    app_path_list = ["open", "-n", "-W", app_path, "--args"] if os_family == "macos" else [app_path]
+                    app_path_list = ["open", "-n", "-W", app_path, "--args"] if os_family == "macos" else [*app_prefix, app_path]
                     app_cmd = app_path_list + app_config
                     if parsed.xvfb:
                         if os_family != "linux":
@@ -264,7 +289,13 @@ class DTCommand(DTCommandAbs):
                         app_cmd = ["xvfb-run", "-a", *xvfb_args, "--", *app_cmd]
                     dtslogger.debug(f"$ > {app_cmd}")
                     time.sleep(2)
-                    renderer = subprocess.Popen(app_cmd, stdout=subprocess.PIPE)
+                    try:
+                        renderer = subprocess.Popen(app_cmd, stdout=subprocess.PIPE)
+                    except OSError as error:
+                        if error.errno == errno.ENOEXEC:
+                            show_exec_format_error(os_family, app_path)
+                            return
+                        raise
                     # this is how we terminate the renderer
 
                     def terminate_renderer(*_):
@@ -310,3 +341,72 @@ def join_renderer(process: subprocess.Popen, verbose: bool = False):
             return
         if verbose:
             print(line, end="")
+
+
+def is_arm64_machine() -> bool:
+    machine = platform.machine()
+    return machine.lower() in ARM64_MACHINES
+
+
+def should_run_linux_renderer_through_fex(os_family: str) -> bool:
+    return (
+        os_family == "linux"
+        and platform.system() == "Linux"
+        and is_arm64_machine()
+    )
+
+
+def is_arm64_windows_host(os_family: str) -> bool:
+    return os_family == "windows" and is_arm64_machine()
+
+
+def find_fex_executable() -> Optional[str]:
+    for executable in FEX_EXECUTABLES:
+        executable_path = which(executable)
+        if executable_path is not None:
+            return executable_path
+    return None
+
+
+def format_fex_renderer_message(*, launch_failed: bool = False, app_path: Optional[str] = None) -> str:
+    if launch_failed:
+        message = (
+            "Failed to execute the native Linux Duckiematrix renderer.\n"
+            "This host is ARM64 and the renderer binary is x86-64, so it must be run through "
+            "FEX-EMU with an x86-64 RootFS configured.\n"
+            f"{FEX_SETUP_GUIDANCE}"
+        )
+    else:
+        message = (
+            "The native Linux Duckiematrix renderer is an x86-64 binary, "
+            "but this host is ARM64.\n"
+            "Install and configure FEX-EMU, then rerun this command.\n"
+            f"{FEX_SETUP_GUIDANCE}"
+        )
+    if app_path is not None:
+        message += f"\nRenderer path: {app_path}"
+    return message
+
+
+def format_windows_arm64_renderer_message(app_path: Optional[str] = None) -> str:
+    message = (
+        "Failed to execute the native Windows Duckiematrix renderer.\n"
+        "This host is ARM64 and the renderer binary is x86-64, so it relies on Windows "
+        "x64 emulation support.\n"
+        f"{WINDOWS_ARM64_SETUP_GUIDANCE}"
+    )
+    if app_path is not None:
+        message += f"\nRenderer path: {app_path}"
+    return message
+
+
+def show_exec_format_error(os_family: str, app_path: str):
+    if should_run_linux_renderer_through_fex(os_family):
+        message = format_fex_renderer_message(launch_failed=True, app_path=app_path)
+        dtslogger.error(message)
+        return
+    if is_arm64_windows_host(os_family):
+        message = format_windows_arm64_renderer_message(app_path=app_path)
+        dtslogger.error(message)
+        return
+    dtslogger.error(f"Failed to execute renderer binary '{app_path}'.")


### PR DESCRIPTION
This pull request updates the renderer launch logic in `matrix/run/command.py` to improve support for ARM64 hosts, especially for Linux and Windows platforms. It introduces detection for ARM64 machines, adds logic to launch the x86-64 renderer via FEX-EMU on ARM64 Linux, and provides user guidance for both FEX-EMU and Windows x64 emulation scenarios. The changes also improve error handling for unsupported binary formats.

**ARM64 and Renderer Launch Improvements:**

* Added detection for ARM64 machines and logic to launch the Linux renderer through FEX-EMU when running on ARM64 Linux. If FEX-EMU is not found, a user-friendly error message with setup guidance is shown. (`is_arm64_machine`, `should_run_linux_renderer_through_fex`, `find_fex_executable`, `format_fex_renderer_message`, `[[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR29-R39)`, `[[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR132-R143)`, `[[3]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR344-R412)`)
* Added detection for ARM64 Windows hosts and provided information about x64 emulation requirements, with guidance if launch fails. (`is_arm64_windows_host`, `format_windows_arm64_renderer_message`, `[[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR29-R39)`, `[[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR132-R143)`, `[[3]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR344-R412)`)
* Improved error handling for renderer launch failures due to invalid executable format (`ENOEXEC`), displaying specific guidance based on the platform and renderer type. (`show_exec_format_error`, `[[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR292-R298)`, `[[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR344-R412)`)

**Code Structure and Robustness:**

* Refactored renderer launch code to use an `app_prefix` (for FEX-EMU) when needed, ensuring the correct command is constructed for different platforms. (`[[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR96)`, `[[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aL254-R279)`)
* Added new constants and helper functions to centralize platform-specific logic and user guidance messages. (`[[1]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR29-R39)`, `[[2]](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR344-R412)`)

These changes make the renderer launch process more robust and user-friendly across different architectures, particularly improving support and guidance for ARM64 users.