### PR TITLE
fix: reconcile compose project labels before stack up (DTSW-7858)

### DIFF
--- a/stack/up/command.py
+++ b/stack/up/command.py
@@ -119,12 +119,14 @@ class DTCommand(DTCommandAbs):
                         dtslogger.error(msg)
                         continue
             # Reconcile compose project labels. Containers declared with
-            # `container_name:` are global by name; if one exists labeled with a
-            # different compose project than the one we're about to use, docker
-            # compose refuses to (re)create it ("container name already in use").
-            # This happens on fresh Raspberry Pi flashes where the SD-card boot
-            # script `dt-run-basics-stacks` brings up robot/basics with project
-            # `basics` while stack/up falls back to the compose-file parent dir.
+            # `container_name:` are global by name; if one exists under a
+            # different compose project (or no project at all, e.g. a stale
+            # `docker run` leftover), docker compose refuses to (re)create it
+            # ("container name already in use"). Happens on fresh Raspberry Pi
+            # flashes where `dt-run-basics-stacks` brings up robot/basics with
+            # project `basics` while stack/up falls back to the compose-file
+            # parent dir, and on robots carrying orphan containers from prior
+            # ad-hoc runs.
             target_project = stack_content.get("name") or os.path.basename(
                 os.path.dirname(stack_file)
             )
@@ -144,13 +146,16 @@ class DTCommand(DTCommandAbs):
                         existing_project = ctr.labels.get(
                             "com.docker.compose.project", ""
                         )
-                        if not existing_project or existing_project == target_project:
+                        if existing_project == target_project:
                             continue
+                        reason = (
+                            f"compose project '{existing_project}' != '{target_project}'"
+                            if existing_project
+                            else f"orphan (no compose project label) blocking '{target_project}'"
+                        )
                         dtslogger.info(
-                            f"Removing legacy container '{cname}' "
-                            f"(compose project '{existing_project}' != "
-                            f"'{target_project}') to let stack "
-                            f"[{target_project}]({stack_name}) recreate it."
+                            f"Removing legacy container '{cname}' ({reason}) "
+                            f"to let stack [{target_project}]({stack_name}) recreate it."
                         )
                         try:
                             if ctr.status == "running":

--- a/stack/up/command.py
+++ b/stack/up/command.py
@@ -11,6 +11,7 @@ from utils.avahi_utils import wait_for_service
 from utils.cli_utils import start_command_in_subprocess
 from utils.docker_utils import (
     DEFAULT_DOCKER_TCP_PORT,
+    get_client_OLD,
     get_endpoint_architecture,
     get_registry_to_use,
     pull_image_OLD,
@@ -98,11 +99,12 @@ class DTCommand(DTCommandAbs):
             if not os.path.isfile(stack_file):
                 dtslogger.error(f"Stack [{project_name}]({stack_name}) not found.")
                 continue
+            # parse stack file once for both pre-flight steps below
+            with open(stack_file, "r") as fin:
+                stack_content = yaml.safe_load(fin)
             # pull images
             processed: Set[str] = set()
             if parsed.pull:
-                with open(stack_file, "r") as fin:
-                    stack_content = yaml.safe_load(fin)
                 for service in stack_content["services"].values():
                     image_name = service["image"].replace("${ARCH}", endpoint_arch)
                     image_name = image_name.replace("${REGISTRY}", registry_to_use)
@@ -116,6 +118,52 @@ class DTCommand(DTCommandAbs):
                         msg = f"Image '{image_name}' not found on registry '{registry_to_use}'. Aborting."
                         dtslogger.error(msg)
                         continue
+            # Reconcile compose project labels. Containers declared with
+            # `container_name:` are global by name; if one exists labeled with a
+            # different compose project than the one we're about to use, docker
+            # compose refuses to (re)create it ("container name already in use").
+            # This happens on fresh Raspberry Pi flashes where the SD-card boot
+            # script `dt-run-basics-stacks` brings up robot/basics with project
+            # `basics` while stack/up falls back to the compose-file parent dir.
+            target_project = stack_content.get("name") or os.path.basename(
+                os.path.dirname(stack_file)
+            )
+            declared_container_names = {
+                svc["container_name"]
+                for svc in stack_content.get("services", {}).values()
+                if "container_name" in svc
+            }
+            if declared_container_names:
+                try:
+                    robot_client = get_client_OLD(hostname)
+                    for cname in declared_container_names:
+                        try:
+                            ctr = robot_client.containers.get(cname)
+                        except NotFound:
+                            continue
+                        existing_project = ctr.labels.get(
+                            "com.docker.compose.project", ""
+                        )
+                        if not existing_project or existing_project == target_project:
+                            continue
+                        dtslogger.info(
+                            f"Removing legacy container '{cname}' "
+                            f"(compose project '{existing_project}' != "
+                            f"'{target_project}') to let stack "
+                            f"[{target_project}]({stack_name}) recreate it."
+                        )
+                        try:
+                            if ctr.status == "running":
+                                ctr.stop(timeout=10)
+                            ctr.remove(force=True)
+                        except Exception as e:
+                            dtslogger.warning(
+                                f"Could not remove conflicting container '{cname}': {e}"
+                            )
+                except Exception as e:
+                    dtslogger.warning(
+                        f"Could not check for conflicting containers on '{robot}': {e}"
+                    )
             # print info
             dtslogger.info(f"Running stack [{project_name}]({stack_name})...")
             print("------>")


### PR DESCRIPTION
## Summary
- Fix `dts duckiebot update` failing on fresh Raspberry Pi flashes with `Conflict. The container name "/portainer" is already in use`.
- Add a pre-flight reconcile step in `stack/up`: parse the compose file, list services with `container_name:`, and on the robot remove any matching container whose `com.docker.compose.project` label differs from the one `docker compose up` is about to use. Compose can then recreate it under the correct project.
- Also reclaim same-named **orphan** containers that have no `com.docker.compose.project` label at all (e.g. left over from a bare `docker run`). Hit on a real drone (`drone01`) where `dtps` was an orphan and blocked the `duckietown` stack after portainer/kvstore had been reconciled.
- No-op on robots that are already aligned (e.g. virtual robots that boot via `dt-autoboot`, which uses the parent-dir convention).

## Why
Two entry points bring up the same stack with different project names:

| Entry point | File / location | `--project-name` | Resulting `com.docker.compose.project` |
|---|---|---|---|
| `dt-run-basics-stacks` (physical Pi5 first boot) | `disk_image/create/raspberry_pi_arm64v8/disk_template/rootfs/usr/local/bin/dt-run-basics-stacks` | `basics` (explicit) | `basics` |
| `dt-autoboot` (virtual robot) | `infra/dt-virtual-device/.../dt-autoboot` | *(none — falls back to parent dir)* | `robot` |
| `stack/up` (this command) | `stack/up/command.py` | *(none)* | `robot` |

The mismatch was latent until commit `09a840f4` ("Fix dts duckiebot update name conflict DTSW-6776") removed `--project-name` from `stack/up`. Today the first `dts duckiebot update` on a fresh Pi5 finds portainer labeled `project=basics`, tries to recreate it under `project=robot`, and the global container name conflicts → 400.

The orphan variant is a second case of the same class of problem: a container with the right name exists but isn't managed by *any* compose project, so compose still refuses to reuse the name.

## How
On each stack in `stack/up`:
1. Load the YAML once, collect declared `container_name`s and compute the target project (`name:` field if set, else parent-dir basename — matching compose's own derivation order).
2. For each declared container, look it up on the robot. Remove it if either:
   - its `com.docker.compose.project` label is non-empty and differs from the target (the original DTSW-7858 case), or
   - it has no `com.docker.compose.project` label at all (orphan from a bare `docker run`).
3. Then run `docker compose up` as before, which now recreates the container under the right project. The log line distinguishes the two reasons.

Scope is narrow: only containers whose name matches a `container_name:` in the stack about to be brought up are touched — compose was going to (re)create them anyway.

The check is generic — it also fixes incidental cross-project mismatches (e.g. `car-interface` lingering under `project=ros2` when `ros1/duckiebot` is brought up).

## Test plan
- [x] Manual verification on virtual Duckiedrone (`testdrone`, DD24)
  - Clean run: portainer/kvstore already in `project=robot`, reconcile no-ops, update completes.
  - Planted bug: manually relabel portainer to `project=basics`, run update → reconcile logs `Removing legacy container 'portainer' (compose project 'basics' != 'robot')`, recreates it under `project=robot`, update completes.
- [x] Manual verification on virtual Duckiebot (`testbot`, DB21J)
  - Same scenarios — reconcile triggers as expected. Also incidentally fixes a `car-interface` mismatch (`project=ros2` → `ros1`).
  - Re-running `dts duckiebot update` after fix is idempotent (no migration logs the second time).
- [x] Verification on a physical DD24 (`drone01`) carrying the actual bug condition.
  - `portainer` and `kvstore` arrived with `project=basics`; reconcile reclaimed both to `project=robot` and `robot/basics` came up cleanly.
  - `dtps` existed as an orphan (no compose labels) and originally blocked the `duckietown/duckiedrone` stack — extended fix removed it and compose recreated it under `project=duckietown`.

## Notes
- Backwards-compatible: no change to fielded SD cards required; the first `dts duckiebot update` after this lands cleans up the mismatch silently.
- The `project_name = parsed.project or stack.replace("/", "_")` line in `stack/up` (a no-op since commit `09a840f4`) is left alone for now — fixing that is a separate, larger refactor (see also the existing TODO in the file).
- Jira: DTSW-7858

🤖 Generated with [Claude Code](https://claude.com/claude-code)