### PR TITLE
DTSW-7876-Address-the-pkg_resources-is-deprecated-as-an-API-Duckietown-Shell-warning

### DIFF
--- a/__command_set__/requirements.txt
+++ b/__command_set__/requirements.txt
@@ -1,6 +1,7 @@
 # generic dependencies
 netifaces-plus==0.12.*
 docker==6.1.3
+packaging>=23.2,<27
 # docker-compose package removed - codebase uses 'docker compose' CLI (v2), not the Python library
 GitPython==3.1.50
 python-dateutil==2.8.2

--- a/devel/pip/resolve/command.py
+++ b/devel/pip/resolve/command.py
@@ -36,7 +36,7 @@ GOOD_SPECS: Set[str] = {
 REGISTRY_JSON_URL: str = "https://pypi.org/pypi/{package}/json"
 
 
-class Requirement:
+class ParsedRequirement:
     def __init__(
         self,
         raw: str,
@@ -55,7 +55,7 @@ class Requirement:
         return self.raw
 
     @classmethod
-    def parse(cls, raw: str) -> "Requirement":
+    def parse(cls, raw: str) -> "ParsedRequirement":
         stripped = raw.strip()
         cleaned = cls._strip_inline_comment(stripped)
         is_git_requirement = cleaned.startswith("git+")
@@ -226,13 +226,13 @@ class DTCommand(DTCommandAbs):
         # computed mock list
         cache: DTShellDatabase = shell.profile.database("known_python_packages")
         explicit: List[RawUnpinned] = [
-            Requirement.parse(d).name for d in chain(*deps_files.values())
+            ParsedRequirement.parse(d).name for d in chain(*deps_files.values())
             if not d.startswith("#") and len(d.strip()) > 0
         ]
         valid: Set[RawUnpinned] = set(cache.get("valid", []))
         mocked: Set[RawPinned] = set(cache.get("mocked", []))
         for package in computed:
-            r: Requirement = Requirement.parse(package)
+            r: ParsedRequirement = ParsedRequirement.parse(package)
             # check if the package (without pinned version is available), otherwise add it to the mock list
             # - we have seen this package before
             if r.name in valid:
@@ -319,8 +319,8 @@ class DTCommand(DTCommandAbs):
     @staticmethod
     def _check_pinned(deps_file: str, wanted: List[str], strict: bool):
         # parse all deps and remove all comments
-        deps: Dict[int, Requirement] = {
-            i: Requirement.parse(d)
+        deps: Dict[int, ParsedRequirement] = {
+            i: ParsedRequirement.parse(d)
             for i, d in enumerate(wanted)
             if not DTCommand._is_comment(d)
         }
@@ -341,20 +341,20 @@ class DTCommand(DTCommandAbs):
     @staticmethod
     def _resolve_deps(wanted: List[str], pinned: List[str], inherited: List[str]) -> Tuple[List[str], Set[str]]:
         resolved: List[Raw] = []
-        wanted: List[Union[Comment, Requirement]] = [
-            (w if DTCommand._is_comment(w) else Requirement.parse(w)) for w in wanted
+        wanted: List[Union[Comment, ParsedRequirement]] = [
+            (w if DTCommand._is_comment(w) else ParsedRequirement.parse(w)) for w in wanted
         ]
-        pinned: Dict[Raw, Union[Comment, Requirement]] = {
-            p: (p if DTCommand._is_comment(p) else Requirement.parse(p)) for p in pinned
+        pinned: Dict[Raw, Union[Comment, ParsedRequirement]] = {
+            p: (p if DTCommand._is_comment(p) else ParsedRequirement.parse(p)) for p in pinned
         }
-        inherited: Set[RawUnpinned] = {Requirement.parse(p).name.lower().strip() for p in inherited}
+        inherited: Set[RawUnpinned] = {ParsedRequirement.parse(p).name.lower().strip() for p in inherited}
         unmatched: Set[RawPinned] = set(pinned.keys())
         for dep in wanted:
             # keep comments
             if isinstance(dep, Comment):
                 resolved.append(dep)
                 continue
-            rdep: Requirement = dep
+            rdep: ParsedRequirement = dep
             # match with pinned
             found: bool = False
             for dep1, rdep1 in pinned.items():
@@ -371,7 +371,7 @@ class DTCommand(DTCommandAbs):
                 raise UserError(msg)
         # remove unmatched dependencies that are inherited
         unmatched = {
-            u for u in unmatched if Requirement.parse(u).name.lower().strip() not in inherited
+            u for u in unmatched if ParsedRequirement.parse(u).name.lower().strip() not in inherited
         }
         # ---
         return resolved, unmatched

--- a/devel/pip/resolve/command.py
+++ b/devel/pip/resolve/command.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from itertools import chain
 from typing import Optional, List, Union, Dict, Set, Tuple
 
@@ -8,7 +9,7 @@ import argparse
 import requests
 
 from dockertown import DockerClient
-from requirements.requirement import Requirement
+from packaging.requirements import Requirement as PackagingRequirement
 
 from dt_shell import DTCommandAbs, DTShell, dtslogger, UserError
 from dt_shell.database import DTShellDatabase
@@ -33,6 +34,96 @@ GOOD_SPECS: Set[str] = {
     "<",
 }
 REGISTRY_JSON_URL: str = "https://pypi.org/pypi/{package}/json"
+
+
+class Requirement:
+    def __init__(
+        self,
+        raw: str,
+        name: str,
+        specs: List[Tuple[str, str]],
+        vcs: Optional[str],
+        revision: Optional[str],
+    ):
+        self.raw = raw
+        self.name = name
+        self.specs = specs
+        self.vcs = vcs
+        self.revision = revision
+
+    def __str__(self) -> str:
+        return self.raw
+
+    @classmethod
+    def parse(cls, raw: str) -> "Requirement":
+        stripped = raw.strip()
+        cleaned = cls._strip_inline_comment(stripped)
+        is_git_requirement = cleaned.startswith("git+")
+        if is_git_requirement:
+            name = cls._vcs_name(cleaned)
+            revision = cls._vcs_revision(cleaned)
+            specs: List[Tuple[str, str]] = []
+            return cls(raw=raw, name=name, specs=specs, vcs="git", revision=revision)
+        parsed = PackagingRequirement(cleaned)
+        vcs = None
+        revision = None
+        parsed_url = parsed.url
+        if parsed_url:
+            is_git_url = parsed_url.startswith("git+")
+            if is_git_url:
+                vcs = "git"
+                revision = cls._vcs_revision(parsed_url)
+        specs = []
+        for specifier in parsed.specifier:
+            operator = specifier.operator
+            version = specifier.version
+            spec = (operator, version)
+            specs.append(spec)
+        name = parsed.name
+        return cls(raw=raw, name=name, specs=specs, vcs=vcs, revision=revision)
+
+    @staticmethod
+    def _strip_inline_comment(raw: str) -> str:
+        without_comment = re.sub(r"\s+#.*$", "", raw)
+        cleaned = without_comment.strip()
+        return cleaned
+
+    @staticmethod
+    def _vcs_revision(url: str) -> Optional[str]:
+        url_parts = url.split("#", 1)
+        url_without_fragment = url_parts[0]
+        last_slash = url_without_fragment.rfind("/")
+        revision_index = url_without_fragment.rfind("@")
+        if revision_index <= last_slash:
+            return None
+        return url_without_fragment[revision_index + 1:]
+
+    @classmethod
+    def _vcs_name(cls, url: str) -> str:
+        egg_match = re.search(r"[#&]egg=([^&]+)", url)
+        if egg_match:
+            egg_value = egg_match.group(1)
+            egg_parts = egg_value.split("[", 1)
+            name = egg_parts[0]
+            return name
+        url_without_revision = cls._vcs_url_without_revision(url)
+        url_without_revision = url_without_revision.rstrip("/")
+        name_parts = url_without_revision.rsplit("/", 1)
+        name = name_parts[-1]
+        is_git_repository = name.endswith(".git")
+        if is_git_repository:
+            name = name[:-4]
+        return name
+
+    @staticmethod
+    def _vcs_url_without_revision(url: str) -> str:
+        url_parts = url.split("#", 1)
+        url_without_fragment = url_parts[0]
+        last_slash = url_without_fragment.rfind("/")
+        revision_index = url_without_fragment.rfind("@")
+        if revision_index > last_slash:
+            return url_without_fragment[:revision_index]
+        return url_without_fragment
 
 
 class DTCommand(DTCommandAbs):


### PR DESCRIPTION
This pull request introduces improvements to dependency parsing and management in the project. The most significant changes are the switch to using the `packaging` library for requirement parsing, the addition of a custom `Requirement` class to handle both PyPI and VCS requirements, and an update to the dependencies in `requirements.txt`.

**Dependency parsing and management:**

* Introduced a custom `Requirement` class in `devel/pip/resolve/command.py` that parses both standard PyPI requirements and VCS-based requirements, extracting relevant fields such as name, version specifiers, VCS type, and revision. This class also handles inline comments and egg fragments for VCS URLs.
* Replaced the import of `Requirement` from `requirements.requirement` with `packaging.requirements.Requirement` to improve standards compliance and parsing accuracy.
* Added the `packaging` library (version >=23.2,<27) to `__command_set__/requirements.txt` to support the new parsing logic.

These changes make the requirements parsing more robust and future-proof, especially for handling complex dependency specifications.