### PR TITLE
DTSW-7891-Address-daffy-error-on-macOS

### DIFF
--- a/__command_set__/requirements.txt
+++ b/__command_set__/requirements.txt
@@ -1,13 +1,12 @@
 # generic dependencies
 netifaces-plus==0.12.2
 docker==6.1.3
-docker-compose==1.29.2
 GitPython==3.1.41
 python-dateutil==2.8.2
 pytz==2023.3
 # force pyyaml away from specific versions: https://github.com/yaml/pyyaml/issues/724
-pyyaml!=6.0.0,!=5.4.0,!=5.4.1,<7; sys_platform == "linux"
-pyyaml==5.4.1; sys_platform == "darwin"
+# Use 6.0.1+ for pre-built wheels on macOS ARM and to avoid older broken builds.
+pyyaml>=6.0.1,<7
 zeroconf==0.122.0
 
 # duckietown dependencies

--- a/stack/down/command.py
+++ b/stack/down/command.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import pathlib
 from shutil import which
+from typing import List
 
 from dt_shell import DTCommandAbs, DTShell, dtslogger
 from utils.avahi_utils import wait_for_service
@@ -23,6 +24,18 @@ class DTCommand(DTCommandAbs):
     help = "Easy way to remove code from Duckietown robots"
 
     @staticmethod
+    def _docker_compose_command(host: str) -> List[str]:
+        if which("docker-compose") is not None:
+            return ["docker-compose", f"--host={host}"]
+        if which("docker") is not None:
+            return ["docker", f"--host={host}", "compose"]
+        dtslogger.error(
+            "\nThis command requires Docker Compose.\n"
+            "Please, install either the `docker-compose` executable or Docker with the Compose v2 plugin.\n"
+        )
+        return []
+
+    @staticmethod
     def command(shell: DTShell, args):
         # configure arguments
         parser = argparse.ArgumentParser()
@@ -36,13 +49,9 @@ class DTCommand(DTCommandAbs):
         parser.add_argument("stack", nargs=1, default=None)
         parsed, _ = parser.parse_known_args(args=args)
         # ---
-        # verify dependencies
-        if which("docker-compose") is None:
-            dtslogger.error(
-                "\nThis command requires the library `docker-compose`.\n"
-                "Please, install it using the command:\n\n"
-                "\tpip3 install docker-compose\n\n"
-            )
+        H = f"{sanitize_hostname(parsed.machine) if parsed.machine is not None else DEFAULT_MACHINE}:{DEFAULT_DOCKER_TCP_PORT}"
+        compose_command = DTCommand._docker_compose_command(H)
+        if not compose_command:
             return
         # ---
         # try to interpret it as a multi-command
@@ -93,9 +102,8 @@ class DTCommand(DTCommandAbs):
         env["ARCH"] = endpoint_arch
         env["REGISTRY"] = registry_to_use  # FIXME
         # run docker compose stack
-        H = f"{parsed.machine}:{DEFAULT_DOCKER_TCP_PORT}"
         start_command_in_subprocess(
-            ["docker-compose", f"--host={H}", "--project-name", project_name, "--file", stack_file, "down"],
+            compose_command + ["--project-name", project_name, "--file", stack_file, "down"],
             env=env,
         )
         # ---

--- a/stack/up/command.py
+++ b/stack/up/command.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import pathlib
 from shutil import which
+from typing import List
 
 import yaml
 from docker.errors import NotFound
@@ -25,6 +26,18 @@ DUCKIETOWN_STACK = "duckietown"
 
 class DTCommand(DTCommandAbs):
     help = "Easy way to run code on Duckietown robots"
+
+    @staticmethod
+    def _docker_compose_command(host: str) -> List[str]:
+        if which("docker-compose") is not None:
+            return ["docker-compose", f"--host={host}"]
+        if which("docker") is not None:
+            return ["docker", f"--host={host}", "compose"]
+        dtslogger.error(
+            "\nThis command requires Docker Compose.\n"
+            "Please, install either the `docker-compose` executable or Docker with the Compose v2 plugin.\n"
+        )
+        return []
 
     @staticmethod
     def command(shell: DTShell, args):
@@ -53,13 +66,9 @@ class DTCommand(DTCommandAbs):
         parser.add_argument("stack", nargs=1, default=None)
         parsed, _ = parser.parse_known_args(args=args)
         # ---
-        # verify dependencies
-        if which("docker-compose") is None:
-            dtslogger.error(
-                "\nThis command requires the library `docker-compose`.\n"
-                "Please, install it using the command:\n\n"
-                "\tpip3 install docker-compose\n\n"
-            )
+        H = f"{sanitize_hostname(parsed.machine) if parsed.machine is not None else DEFAULT_MACHINE}:{DEFAULT_DOCKER_TCP_PORT}"
+        compose_command = DTCommand._docker_compose_command(H)
+        if not compose_command:
             return False
         # ---
         # try to interpret it as a multi-command
@@ -131,9 +140,8 @@ class DTCommand(DTCommandAbs):
         if parsed.detach:
             docker_arguments.append("--detach")
         # run docker compose stack
-        H = f"{parsed.machine}:{DEFAULT_DOCKER_TCP_PORT}"
         start_command_in_subprocess(
-            ["docker-compose", f"--host={H}", "--project-name", project_name, "--file", stack_file, "up"]
+            compose_command + ["--project-name", project_name, "--file", stack_file, "up"]
             + docker_arguments,
             env=env,
         )


### PR DESCRIPTION
This pull request introduces improved support for both Docker Compose v1 and v2 across the `stack/up/command.py` and `stack/down/command.py` commands, streamlining dependency management and enhancing compatibility. The changes also update the `pyyaml` dependency to ensure better cross-platform support.

**Docker Compose compatibility improvements:**

* Added a `_docker_compose_command` static method in both `stack/up/command.py` and `stack/down/command.py` to dynamically select the appropriate Docker Compose invocation (`docker-compose` for v1 or `docker compose` for v2) based on what is available in the user's environment. This improves compatibility with newer Docker installations and provides clearer error messages if neither is found. [[1]](diffhunk://#diff-f45df42707b047b15222cf6102392972558d1e526d49f832221d41f0adc2926dR30-R41) [[2]](diffhunk://#diff-3d254411caa5c91b6a9a38c310a388c1dd367dc174c10f42fad752d1a2f75e4bR26-R37)
* Updated the logic in the `command` methods of both files to use the new `_docker_compose_command` method, removing the previous hard dependency on the `docker-compose` executable and supporting both v1 and v2 syntax. [[1]](diffhunk://#diff-f45df42707b047b15222cf6102392972558d1e526d49f832221d41f0adc2926dL56-R71) [[2]](diffhunk://#diff-3d254411caa5c91b6a9a38c310a388c1dd367dc174c10f42fad752d1a2f75e4bL39-R54)
* Modified the subprocess calls for bringing stacks up and down to use the dynamically determined Docker Compose command, ensuring consistent behavior regardless of the Compose version. [[1]](diffhunk://#diff-f45df42707b047b15222cf6102392972558d1e526d49f832221d41f0adc2926dL134-R144) [[2]](diffhunk://#diff-3d254411caa5c91b6a9a38c310a388c1dd367dc174c10f42fad752d1a2f75e4bL96-R106)

**Dependency updates:**

* Updated the `pyyaml` requirement in `__command_set__/requirements.txt` to `>=6.0.1,<7` for all platforms, ensuring pre-built wheels are used on macOS ARM and avoiding problematic older builds.

**Code maintenance:**

* Added missing `List` import from `typing` in both command files to support type annotations. [[1]](diffhunk://#diff-f45df42707b047b15222cf6102392972558d1e526d49f832221d41f0adc2926dR5) [[2]](diffhunk://#diff-3d254411caa5c91b6a9a38c310a388c1dd367dc174c10f42fad752d1a2f75e4bR5)