### PR TITLE
DTSW-7926-Add-the-ability-to-disable-PyContracts-in-the-Duckiematrix-engine

### DIFF
--- a/matrix/engine/run/command.py
+++ b/matrix/engine/run/command.py
@@ -212,6 +212,8 @@ class MatrixEngine:
         # profiler
         if parsed.profiler:
             engine_config["command"] += ["--profiler"]
+        if parsed.disable_contracts:
+            engine_config["command"] += ["--disable-contracts"]
         # run engine container
         dtslogger.debug(engine_config)
         self.config = engine_config

--- a/matrix/engine/run/configuration.py
+++ b/matrix/engine/run/configuration.py
@@ -112,6 +112,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             action="store_true",
             help="Enable the profiler"
         )
+        parser.add_argument(
+            "--disable-contracts",
+            default=False,
+            action="store_true",
+            help="Disable PyContracts in the engine"
+        )
         # ---
         return parser
 

--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -134,6 +134,9 @@ class DTCommand(DTCommandAbs):
         if parsed.profiler and not run_engine:
             dtslogger.error("You cannot use --profiler without -S/--standalone.")
             return
+        if parsed.disable_contracts and not run_engine:
+            dtslogger.error("You cannot use --disable-contracts without -S/--standalone.")
+            return
         # configure the engine if in standalone
         engine: Optional[MatrixEngine] = None
         if run_engine:

--- a/matrix/run/configuration.py
+++ b/matrix/run/configuration.py
@@ -163,6 +163,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="Enable the profiler (requires -S/--standalone)",
         )
         parser.add_argument(
+            "--disable-contracts",
+            default=False,
+            action="store_true",
+            help="Disable PyContracts in the standalone engine",
+        )
+        parser.add_argument(
             "-os",
             "--os-family",
             default=None,


### PR DESCRIPTION
This pull request adds support for disabling PyContracts in the engine using a new `--disable-contracts` command-line argument. The argument is available in both the main and standalone engine modes, but is only valid when running in standalone mode. The changes include argument parsing, validation, and passing the flag to the engine configuration.

**New command-line option:**

* Added `--disable-contracts` argument to both `matrix/run/configuration.py` and `matrix/engine/run/configuration.py` to allow users to disable PyContracts in the engine (`[[1]](diffhunk://#diff-16c573ad7c8b32eaea8862ef32a7112b58f251d078011af8ca7fbd3dd3efbdb6R165-R170)`, `[[2]](diffhunk://#diff-0b281844232a646fab546d2a57f5d407a51cc23b423eff8a342696f6a835d4cfR115-R120)`).

**Validation and usage:**

* Updated `matrix/run/command.py` to ensure `--disable-contracts` can only be used with `-S/--standalone`, providing an error otherwise (`[matrix/run/command.pyR137-R139](diffhunk://#diff-645205f1a3f7e07c3f2456c48ce556e0e7ad0b724976d27cae347cf4b211cf8aR137-R139)`).
* Updated `matrix/engine/run/command.py` to append `--disable-contracts` to the engine command if the argument is set (`[matrix/engine/run/command.pyR215-R216](diffhunk://#diff-8b261cb2dff7416ee71276b4e411ab8e391e086b5e457d20dbe9d6d96d32c7baR215-R216)`).