### PR TITLE
DTSW-7949-Add-release-checksum-handling-for-installed-and-remote-versions-of-the-Duckiematrix-renderer

### DIFF
--- a/matrix/install/command.py
+++ b/matrix/install/command.py
@@ -9,10 +9,14 @@ from utils.duckiematrix_utils import \
     APP_NAME, \
     DCSS_SPACE_NAME, \
     APP_RELEASES_DIR, \
+    get_installed_release_checksum, \
     get_most_recent_version_installed, \
+    get_path_to_install, \
+    get_remote_release_checksum, \
     remote_zip_obj, \
     get_latest_version, \
-    get_os_family
+    get_os_family, \
+    write_installed_release_checksum
 
 from utils.misc_utils import versiontuple
 
@@ -38,6 +42,7 @@ class DTCommand(DTCommandAbs):
         else:
             os_family = get_os_family()
         version = parsed.version
+        installed_version = None
         if version:
             latest_version = version
         else:
@@ -50,22 +55,38 @@ class DTCommand(DTCommandAbs):
             # get latest version available on the DCSS
             latest_version = get_latest_version(os_family, webgl)
         latest = latest_version + "-" + ("webgl" if webgl else os_family)
-        if not version:
-            # compare installed and latest versions
-            if installed_version:
-                if installed_version == latest:
-                    return
-                app_dir = os.path.join(APP_RELEASES_DIR, f"v{installed_version}")
-                subprocess.check_call(["rm", "-rf", app_dir])
-        # make sure the same version is not already installed (unless forced)
         app_dir = os.path.join(APP_RELEASES_DIR, f"v{latest}")
+        remote_checksum = None
         if os.path.isdir(app_dir):
-            if not parsed.force:
-                dtslogger.info("You already have the latest version installed.")
+            try:
+                remote_checksum = get_remote_release_checksum(latest_version, os_family, webgl)
+            except Exception as e:
+                dtslogger.debug(f"Could not fetch release checksum for 'v{latest}': {e}")
+            local_checksum = get_installed_release_checksum(os_family, latest_version, webgl)
+            if not parsed.force and remote_checksum is None:
+                dtslogger.info(f"You already have version 'v{latest}' installed.")
                 return
-            else:
-                dtslogger.info(f"Removing installed version 'v{latest}'...")
-                subprocess.check_call(["rm", "-rf", app_dir])
+            if not parsed.force and local_checksum == remote_checksum:
+                dtslogger.info(f"You already have version 'v{latest}' installed.")
+                return
+            if not parsed.force:
+                if local_checksum is None:
+                    dtslogger.info(
+                        f"Installed version 'v{latest}' has no stored checksum."
+                    )
+                else:
+                    dtslogger.info(
+                        f"Installed version 'v{latest}' differs from the release checksum."
+                    )
+            dtslogger.info(f"Removing installed version 'v{latest}'...")
+            subprocess.check_call(["rm", "-rf", app_dir])
+        elif not version and installed_version is not None and installed_version != latest_version:
+            installed_app_dir = get_path_to_install(os_family, installed_version, webgl)
+            if installed_app_dir is not None:
+                dtslogger.info(
+                    f"Removing installed version 'v{installed_version}-{('webgl' if webgl else os_family)}'..."
+                )
+                subprocess.check_call(["rm", "-rf", installed_app_dir])
         # download
         dtslogger.info(f"Downloading version v{latest}...")
         os.makedirs(app_dir)
@@ -83,6 +104,13 @@ class DTCommand(DTCommandAbs):
         # install
         dtslogger.info("Installing...")
         subprocess.check_call(["unzip", f"v{latest}.zip"], cwd=app_dir)
+        if remote_checksum is None:
+            try:
+                remote_checksum = get_remote_release_checksum(latest_version, os_family, webgl)
+            except Exception as e:
+                dtslogger.debug(f"Could not store release checksum for 'v{latest}': {e}")
+        if remote_checksum is not None:
+            write_installed_release_checksum(app_dir, remote_checksum)
         # clean up
         dtslogger.info("Removing temporary files...")
         os.remove(zip_local)

--- a/utils/duckiematrix_utils.py
+++ b/utils/duckiematrix_utils.py
@@ -1,9 +1,10 @@
 import glob
+import json
 import os
 import platform
 import re
 import sys
-from typing import List, Optional
+from typing import List, Mapping, Optional
 
 from dt_data_api import DataClient
 
@@ -16,6 +17,7 @@ DCSS_APP_DIR = f"assets/{APP_NAME}/"
 DCSS_APP_RELEASES_DIR = f"assets/{APP_NAME}/releases/"
 APP_LOCAL_DIR = os.path.join(USER_DATA_DIR, APP_NAME)
 APP_RELEASES_DIR = os.path.join(APP_LOCAL_DIR, "releases")
+RELEASE_METADATA_FILENAME = ".release.json"
 
 
 def get_os_family() -> str:
@@ -88,6 +90,67 @@ def get_path_to_app(os_family: str, version: str, webgl: bool = False):
     else:
         return None
     return os.path.join(app_dir, f"{app_name}.{ext}")
+
+
+def _normalize_checksum(checksum: Optional[str]) -> Optional[str]:
+    if checksum is None:
+        return None
+    checksum = checksum.strip()
+    checksum = checksum.strip('"')
+    return checksum.strip("'") or None
+
+
+def get_release_checksum(metadata: Mapping[str, str]) -> Optional[str]:
+    for key in (
+        "ETag",
+        "Etag",
+        "etag",
+        "Content-MD5",
+        "Content-Md5",
+        "content-md5",
+        "x-amz-checksum-sha256",
+        "x-amz-meta-sha256",
+    ):
+        checksum = metadata.get(key)
+        if checksum:
+            return _normalize_checksum(checksum)
+    return None
+
+
+def get_remote_release_checksum(version: str, os_family: str = "", webgl: bool = False) -> Optional[str]:
+    client = DataClient()
+    storage = client.storage(DCSS_SPACE_NAME)
+    release_obj = remote_zip_obj(version, os_family, webgl)
+    metadata = storage.head(release_obj)
+    return get_release_checksum(metadata)
+
+
+def get_installed_release_checksum(os_family: str, version: str, webgl: bool = False) -> Optional[str]:
+    app_dir = get_path_to_install(os_family, version, webgl)
+    if app_dir is None:
+        return None
+    metadata_fp = os.path.join(app_dir, RELEASE_METADATA_FILENAME)
+    if not os.path.isfile(metadata_fp):
+        return None
+    try:
+        with open(metadata_fp, "rt", encoding="utf-8") as fin:
+            metadata = json.load(fin)
+    except (OSError, TypeError, ValueError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    checksum = metadata.get("checksum")
+    return _normalize_checksum(checksum)
+
+
+def write_installed_release_checksum(app_dir: str, checksum: Optional[str]) -> None:
+    metadata = {
+        "checksum": _normalize_checksum(checksum)
+    }
+    metadata_fp = os.path.join(app_dir, RELEASE_METADATA_FILENAME)
+    with open(metadata_fp, "wt", encoding="utf-8") as fout:
+        json.dump(metadata, fout, indent=4, sort_keys=True)
+        fout.write("\n")
 
 
 def is_version_released(version: str, os_family: str = "") -> bool:


### PR DESCRIPTION
This pull request enhances the installation process by adding checksum verification for app releases, ensuring the integrity of installed versions and enabling more robust update logic. The main changes include fetching and storing release checksums, comparing local and remote versions, and improving how outdated or mismatched installations are handled.

**Checksum Verification and Storage:**

* Added functions to fetch remote release checksums (`get_remote_release_checksum`) and read/write installed release checksums (`get_installed_release_checksum`, `write_installed_release_checksum`) using a new `.release.json` metadata file.
* Implemented normalization and extraction of checksums from release metadata for consistent comparison.

**Install Command Logic Improvements:**

* Updated the install command to check if the installed version matches the remote checksum, only reinstalling if there is a mismatch or if forced.
* Enhanced removal logic to clean up outdated or mismatched installations before installing a new version.
* After installation, the remote checksum is stored locally for future integrity checks.

**Imports and Constants:**

* Added new imports and constants to support checksum operations and metadata file handling. [[1]](diffhunk://#diff-eb642d143aa72bd6e0aa5fdb707928d07a397f135ae97263d1c596d773f3dc93R12-R19) [[2]](diffhunk://#diff-eb344d0721cc05c84853c089e9619848983346fbae363fdf1d8db9a2988469f1R2-R7) [[3]](diffhunk://#diff-eb344d0721cc05c84853c089e9619848983346fbae363fdf1d8db9a2988469f1R20)