### PR TITLE
DTSW-7973-Add-Duckiematrix-interface

### DIFF
--- a/stack/stacks/robot/duckiematrix.yaml
+++ b/stack/stacks/robot/duckiematrix.yaml
@@ -29,3 +29,19 @@ services:
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  ros2-duckiematrix-interface:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-duckiematrix-interface
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_LAUNCHER: duckiematrix-interface
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket


### PR DESCRIPTION
This pull request adds a new service definition to the `duckiematrix.yaml` stack configuration. The main change is the introduction of the `ros2-duckiematrix-interface` service, which is configured to run with appropriate environment variables, volume mounts, and privileges.

New service addition:

* Added the `ros2-duckiematrix-interface` service to the stack, specifying its image, container name, restart policy, network mode, privileges, environment variables, and necessary volume mounts for DTPS and Avahi sockets.