### PR TITLE
DTSW-7999-Add-driver-camera-to-duckietown-duckiedrone-stack

### DIFF
--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -15,6 +15,24 @@ services:
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
+  driver-camera:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-camera
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    pid: host
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-camera
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 0.1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
   driver-tof:
     image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
     container_name: driver-tof


### PR DESCRIPTION
This pull request adds a new service to the `duckiedrone.yaml` stack configuration, specifically introducing a `driver-camera` container. This service is configured similarly to existing sensor drivers and is set up to handle camera input.

New service addition:

* Added a `driver-camera` service to the `services` section of `duckiedrone.yaml`, using the `dt-duckiebot-interface` image with the `sensor-camera` launcher, and configured it with appropriate environment variables, host networking, privileged mode, and necessary volume mounts.