### PR TITLE
DTSW-8001-Add-support-for-every-ToF-sensor

### DIFF
--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -15,15 +15,83 @@ services:
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
-  driver-tof:
+  driver-tof-bottom:
     image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
-    container_name: driver-tof
+    container_name: driver-tof-bottom
     restart: unless-stopped
     network_mode: host
     privileged: true
     environment:
       DT_SUPERUSER: 1
-      DT_LAUNCHER: sensor-tof
+      DT_LAUNCHER: sensor-tof-bottom
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-tof-front:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-tof-front
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-tof-front
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-tof-left:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-tof-left
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-tof-left
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-tof-right:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-tof-right
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-tof-right
+      DTPS_DATA_AVAILABILITY_TIMEOUT: 1
+    volumes:
+      - /data:/data
+      # dtps sockets
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+  driver-tof-top:
+    image: ${REGISTRY}/duckietown/dt-duckiebot-interface:ente-${ARCH}
+    container_name: driver-tof-top
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    environment:
+      DT_SUPERUSER: 1
+      DT_LAUNCHER: sensor-tof-top
       DTPS_DATA_AVAILABILITY_TIMEOUT: 1
     volumes:
       - /data:/data

--- a/stack/stacks/ros2/duckiedrone.yaml
+++ b/stack/stacks/ros2/duckiedrone.yaml
@@ -49,6 +49,78 @@ services:
     depends_on:
       - zenoh-router
 
+  tof-front:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-tof-front
+    restart: unless-stopped
+    network_mode: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-tof-front
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
+  tof-left:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-tof-left
+    restart: unless-stopped
+    network_mode: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-tof-left
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
+  tof-right:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-tof-right
+    restart: unless-stopped
+    network_mode: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-tof-right
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
+  tof-top:
+    image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
+    container_name: ros2-tof-top
+    restart: unless-stopped
+    network_mode: host
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      DT_LAUNCHER: sensor-tof-top
+      DT_SUPERUSER: 1
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data/ramdisk/dtps:/dtps
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+    depends_on:
+      - zenoh-router
+
   mavros:
     image: ${REGISTRY}/duckietown/dt-ros2-interface:ente-${ARCH}
     container_name: ros2-mavros


### PR DESCRIPTION
This pull request expands and refines the configuration for Time-of-Flight (ToF) sensor drivers in both the Duckiedrone system stack and its ROS2 integration. The main changes involve splitting the ToF sensor drivers into individual services for each sensor position (front, left, right, top, bottom), improving modularity and clarity, and ensuring consistent environment and volume settings across all ToF-related services.

**Duckiedrone stack (`duckiedrone.yaml`):**

* Refactored the original `driver-tof` service into five separate services: `driver-tof-bottom`, `driver-tof-front`, `driver-tof-left`, `driver-tof-right`, and `driver-tof-top`, each configured for a specific sensor position with appropriate `DT_LAUNCHER` values and consistent volume mounts.

**ROS2 stack (`duckiedrone.yaml`):**

* Added four new services: `tof-front`, `tof-left`, `tof-right`, and `tof-top`, each corresponding to a specific ToF sensor position, with standardized environment variables, security options, and volume mounts for integration with the ROS2 system.