### PR TITLE
DTSW-8008-dts-docs-build-does-not-work

### DIFF
--- a/docs/build/command.py
+++ b/docs/build/command.py
@@ -16,6 +16,7 @@ from utils.docker_utils import (
     sanitize_docker_baseurl,
     get_cloud_builder,
 )
+from utils.docs_utils import CONTAINER_BUILD_CACHE_DIR, get_host_build_cache_dir
 from dtproject import DTProject
 from dt_shell.exceptions import ShellNeedsUpdate
 
@@ -30,8 +31,6 @@ from dockertown import DockerClient
 
 CONTAINER_HTML_DIR = "tmp/jb/_build/html"
 CONTAINER_PDF_DIR = "tmp/jb/_build/pdf"
-CONTAINER_BUILD_CACHE_DIR = "/tmp/jb"
-HOST_BUILD_CACHE_DIR = "/tmp/duckietown/docs/{book}"
 
 DCSS_RSA_SECRET_LOCATION = "secrets/rsa/ssh-{dns}/id_rsa"
 DCSS_RSA_SECRET_SPACE = "private"
@@ -299,13 +298,9 @@ class DTCommand(DTCommandAbs):
 
             # build cache
             if not parsed.no_cache:
-                build_cache: str = HOST_BUILD_CACHE_DIR.format(book=project.name)
-                try:
-                    os.makedirs(build_cache, exist_ok=True)
-                except Exception:
-                    pass
-                if os.path.exists(build_cache):
-                    volumes.append((build_cache, CONTAINER_BUILD_CACHE_DIR, mount_flags("rw")))
+                build_cache: str = get_host_build_cache_dir(project.name)
+                os.makedirs(build_cache, exist_ok=True)
+                volumes.append((build_cache, CONTAINER_BUILD_CACHE_DIR, mount_flags("rw")))
 
             # log reader from container
             def consume_container_logs(_logs):

--- a/docs/clean/command.py
+++ b/docs/clean/command.py
@@ -8,6 +8,7 @@ from dt_shell import DTCommandAbs, DTShell, dtslogger
 from dtproject import DTProject
 
 from utils.docker_utils import get_registry_to_use, get_endpoint_architecture
+from utils.docs_utils import CONTAINER_BUILD_CACHE_DIR, get_host_build_cache_dir
 from dt_shell.exceptions import ShellNeedsUpdate
 
 # NOTE: this is to avoid breaking the user workspace
@@ -16,9 +17,6 @@ try:
 except ImportError:
     raise ShellNeedsUpdate("5.4.0+")
 # NOTE: this is to avoid breaking the user workspace
-
-CONTAINER_BUILD_CACHE_DIR = "/tmp/jb"
-HOST_BUILD_CACHE_DIR = "/tmp/duckietown/docs/{book}"
 
 SUPPORTED_PROJECT_TYPES = {
     "template-book": {"2", "4"},
@@ -103,9 +101,9 @@ class DTCommand(DTCommandAbs):
             volumes.append((pdf_dir, "/out/pdf", "rw"))
 
         # build cache
-        build_cache: str = HOST_BUILD_CACHE_DIR.format(book=project.name)
-        if os.path.exists(build_cache):
-            volumes.append((build_cache, CONTAINER_BUILD_CACHE_DIR, "rw"))
+        build_cache: str = get_host_build_cache_dir(project.name)
+        os.makedirs(build_cache, exist_ok=True)
+        volumes.append((build_cache, CONTAINER_BUILD_CACHE_DIR, "rw"))
 
         # start the clean process
         dtslogger.info(f"Cleaning project '{project.name}'...")

--- a/utils/docs_utils.py
+++ b/utils/docs_utils.py
@@ -1,0 +1,21 @@
+import os
+
+
+CONTAINER_BUILD_CACHE_DIR = "/tmp/jb"
+LEGACY_HOST_BUILD_CACHE_DIR = "/tmp/duckietown/docs/{book}"
+HOME_DIR = os.path.expanduser("~")
+FALLBACK_HOST_BUILD_CACHE_DIR = os.path.join(HOME_DIR, ".cache", "duckietown", "docs", "{book}")
+
+
+def get_host_build_cache_dir(book_name: str) -> str:
+    legacy_build_cache = LEGACY_HOST_BUILD_CACHE_DIR.format(book=book_name)
+    fallback_build_cache = FALLBACK_HOST_BUILD_CACHE_DIR.format(book=book_name)
+    candidate_dirs = (legacy_build_cache, fallback_build_cache)
+    for build_cache in candidate_dirs:
+        try:
+            os.makedirs(build_cache, exist_ok=True)
+        except OSError:
+            continue
+        if os.path.isdir(build_cache):
+            return build_cache
+    raise OSError(f"Could not create a writable docs build cache directory for '{book_name}'.")


### PR DESCRIPTION
This pull request refactors how build cache directories are handled in the `docs/build` and `docs/clean` commands. The main improvement is centralizing the logic for determining and creating host-side build cache directories into a new utility function, which increases maintainability and reliability. The most important changes are:

**Centralization of build cache logic:**
* Introduced `get_host_build_cache_dir()` in `utils/docs_utils.py`, which selects and creates a writable host build cache directory, preferring a legacy path and falling back to a user-specific cache if needed. This function raises an error if no suitable directory can be created. (`[utils/docs_utils.pyR1-R21](diffhunk://#diff-de67e98d3c05394e722f21661e5fd7ce85b156289f15ea1781e10eb26bbc7ff8R1-R21)`)
* Moved the definitions of `CONTAINER_BUILD_CACHE_DIR` and the host cache directory paths to `utils/docs_utils.py` for reuse and consistency. (`[utils/docs_utils.pyR1-R21](diffhunk://#diff-de67e98d3c05394e722f21661e5fd7ce85b156289f15ea1781e10eb26bbc7ff8R1-R21)`)

**Refactoring usage in commands:**
* Updated `docs/build/command.py` and `docs/clean/command.py` to use `get_host_build_cache_dir()` and the centralized constants, removing duplicated path definitions and directory creation logic. (`[[1]](diffhunk://#diff-ce29099e441cae4a36ada58b348657a7f0776838f98ddf06c3308d61e1607b64R19)`, `[[2]](diffhunk://#diff-ce29099e441cae4a36ada58b348657a7f0776838f98ddf06c3308d61e1607b64L33-L34)`, `[[3]](diffhunk://#diff-ce29099e441cae4a36ada58b348657a7f0776838f98ddf06c3308d61e1607b64L302-L307)`, `[[4]](diffhunk://#diff-871dc3cfcfafa11ce4bfdc943cf9d3ab589b06a8968bd33c6aac4a126c85b00fR11)`, `[[5]](diffhunk://#diff-871dc3cfcfafa11ce4bfdc943cf9d3ab589b06a8968bd33c6aac4a126c85b00fL20-L22)`, `[[6]](diffhunk://#diff-871dc3cfcfafa11ce4bfdc943cf9d3ab589b06a8968bd33c6aac4a126c85b00fL106-R105)`)

These changes improve code maintainability and ensure that the build cache logic is consistent and robust across commands.