### PR TITLE
DTSW-8036-dts-disk_image-create-does-not-work

### DIFF
--- a/disk_image/create/constants.py
+++ b/disk_image/create/constants.py
@@ -71,6 +71,7 @@ MODULES_TO_LOAD = [
 
 CLI_TOOLS_NEEDED = [
     "wget",
+    "zip",
     "unzip",
     "sudo",
     "cp",

--- a/disk_image/create/constants.py
+++ b/disk_image/create/constants.py
@@ -1,7 +1,39 @@
+import os
+
+
 PARTITION_MOUNTPOINT = lambda partition: f"/media/dts/{partition}"
 DISK_DEVICE = lambda device, partition_id: f"{device}p{partition_id}"
 FILE_PLACEHOLDER_SIGNATURE = "DT_DUCKIETOWN_PLACEHOLDER_"
-TMP_WORKDIR = "/tmp/duckietown/dts/disk_image"
+LEGACY_TMP_WORKDIR = "/tmp/duckietown/dts/disk_image"
+HOME_DIR = os.path.expanduser("~")
+FALLBACK_TMP_WORKDIR = os.path.join(HOME_DIR, ".cache", "duckietown", "dts", "disk_image")
+
+
+def _get_existing_parent_dir(path: str) -> str:
+    parent_dir = path
+    while not os.path.isdir(parent_dir):
+        next_parent_dir = os.path.dirname(parent_dir)
+        if next_parent_dir == parent_dir:
+            break
+        parent_dir = next_parent_dir
+    return parent_dir
+
+
+def _can_create_workdir(path: str) -> bool:
+    existing_parent_dir = _get_existing_parent_dir(path)
+    required_mode = os.W_OK | os.X_OK
+    return os.access(existing_parent_dir, required_mode)
+
+
+def _get_tmp_workdir() -> str:
+    candidate_dirs = (LEGACY_TMP_WORKDIR, FALLBACK_TMP_WORKDIR)
+    for workdir in candidate_dirs:
+        if _can_create_workdir(workdir):
+            return workdir
+    raise OSError("Could not determine a writable disk image working directory.")
+
+
+TMP_WORKDIR = _get_tmp_workdir()
 DISK_IMAGE_STATS_LOCATION = "data/stats/disk_image/build.json"
 DATA_STORAGE_DISK_IMAGE_DIR = "disk_image"
 DEFAULT_STACK = "duckietown"

--- a/disk_image/create/constants.py
+++ b/disk_image/create/constants.py
@@ -84,6 +84,8 @@ CLI_TOOLS_NEEDED = [
     "e2fsck",
     "resize2fs",
     "truncate",
+    "mkfs.fat",
+    "fatlabel",
     "mount",
     "umount",
     "touch",

--- a/disk_image/create/constants.py
+++ b/disk_image/create/constants.py
@@ -90,6 +90,7 @@ CLI_TOOLS_NEEDED = [
     "chroot",
     "fdisk",
     "gdisk",
+    "mknod",
     "chmod",
     "rm",
     "docker",

--- a/disk_image/create/jetson_nano/private_command.py
+++ b/disk_image/create/jetson_nano/private_command.py
@@ -6,6 +6,7 @@ import argparse
 import pathlib
 import json
 import os
+import platform
 import shutil
 import subprocess
 import time
@@ -532,26 +533,31 @@ class DTCommand(DTCommandAbs):
                     raise ValueError(f"Disk device {root_partition_disk} not found")
                 # mount `root` partition
                 sd_card.mount_partition(ROOT_PARTITION)
+                host_machine = platform.machine()
+                host_machine = host_machine.lower()
+                host_runs_arm64_natively = host_machine in {"aarch64", "arm64"}
                 # dev partition from the host is mounted to _dev
                 _dev = os.path.join(PARTITION_MOUNTPOINT(ROOT_PARTITION), "dev")
                 # from this point on, if anything weird happens, unmount the `root` disk
                 try:
                     # copy QEMU, resolvconf
-                    _transfer_file(ROOT_PARTITION, ["usr", "bin", "qemu-aarch64-static"])
                     _transfer_file(ROOT_PARTITION, ["run", "resolvconf", "resolv.conf"])
+                    if not host_runs_arm64_natively:
+                        _transfer_file(ROOT_PARTITION, ["usr", "bin", "qemu-aarch64-static"])
                     # mount /dev from the host
                     run_cmd(["sudo", "mount", "--bind", "/dev", _dev])
-                    # configure the kernel for QEMU
-                    run_cmd(
-                        [
-                            "docker",
-                            "run",
-                            "--rm",
-                            "--privileged",
-                            "multiarch/qemu-user-static:register",
-                            "--reset",
-                        ]
-                    )
+                    # configure the kernel for QEMU only for non-native hosts
+                    if not host_runs_arm64_natively:
+                        run_cmd(
+                            [
+                                "docker",
+                                "run",
+                                "--rm",
+                                "--privileged",
+                                "multiarch/qemu-user-static:register",
+                                "--reset",
+                            ]
+                        )
                     # try running a simple echo from the new chroot, if an error occurs, we need
                     # to check the QEMU configuration
                     try:
@@ -561,16 +567,25 @@ class DTCommand(DTCommandAbs):
                         if "Exec format error" in output:
                             raise Exception("Exec format error")
                     except (BaseException, subprocess.CalledProcessError) as e:
-                        dtslogger.error(
-                            "An error occurred while trying to run an ARM binary "
-                            "from the temporary chroot.\n"
-                            "This usually indicates a misconfiguration of QEMU "
-                            "on the host.\n"
-                            "Please, make sure that you have the packages "
-                            "'qemu-user-static' and 'binfmt-support' installed "
-                            "via APT.\n\n"
-                            "The full error is:\n\t%s" % str(e)
-                        )
+                        if host_runs_arm64_natively:
+                            dtslogger.error(
+                                "An error occurred while trying to run an ARM binary "
+                                "from the temporary chroot.\n"
+                                f"The current host reports architecture '{host_machine}', "
+                                "so the chroot was expected to run natively.\n\n"
+                                "The full error is:\n\t%s" % str(e)
+                            )
+                        else:
+                            dtslogger.error(
+                                "An error occurred while trying to run an ARM binary "
+                                "from the temporary chroot.\n"
+                                "This usually indicates a misconfiguration of QEMU "
+                                "on the host.\n"
+                                "Please, make sure that you have the packages "
+                                "'qemu-user-static' and 'binfmt-support' installed "
+                                "via APT.\n\n"
+                                "The full error is:\n\t%s" % str(e)
+                            )
                         exit(2)
                     # Fix the incorrect base image password for the `duckie` user (it should be `quackquack` rather than `quack`)
                     try:

--- a/disk_image/create/jetson_nano/private_command.py
+++ b/disk_image/create/jetson_nano/private_command.py
@@ -396,6 +396,16 @@ class DTCommand(DTCommandAbs):
                 if not granted:
                     dtslogger.info("Aborting.")
                     return
+            existing_loopdev = VirtualSDCard.find_loopdev(
+                out_file_path("img"), quiet=True, include_deleted=True
+            )
+            if existing_loopdev:
+                dtslogger.warning(
+                    f"The destination file {out_file_path('img')} is still mounted to {existing_loopdev}. "
+                    "Detaching it before overwrite."
+                )
+                sd_card.set_loopdev(existing_loopdev)
+                sd_card.umount()
             # create empty disk image
             if not using_cached_step:
                 dtslogger.info(f"Creating empty disk image [{out_file_path('img')}]")

--- a/disk_image/create/jetson_orin_nano/private_command.py
+++ b/disk_image/create/jetson_orin_nano/private_command.py
@@ -303,8 +303,12 @@ class DTCommand(DTCommandAbs):
                     continue
                 parsed.steps.discard(step)
             using_cached_step = True
-        # verify that the input image exists before proceeding with create/mount steps
-        if "create" in parsed.steps and not os.path.isfile(disk_image_origin):
+        # verify that the input image exists only when create depends on a pre-existing source image
+        if (
+            "create" in parsed.steps
+            and "download" not in parsed.steps
+            and not os.path.isfile(disk_image_origin)
+        ):
             dtslogger.error(
                 f"Input image file not found at {disk_image_origin}. "
                 f"Please ensure the 'download' step is included or provide a valid --input-image."

--- a/disk_image/create/jetson_orin_nano/private_command.py
+++ b/disk_image/create/jetson_orin_nano/private_command.py
@@ -432,6 +432,16 @@ class DTCommand(DTCommandAbs):
                 if not granted:
                     dtslogger.info("Aborting.")
                     return
+            existing_loopdev = VirtualSDCard.find_loopdev(
+                out_file_path("img"), quiet=True, include_deleted=True
+            )
+            if existing_loopdev:
+                dtslogger.warning(
+                    f"The destination file {out_file_path('img')} is still mounted to {existing_loopdev}. "
+                    "Detaching it before overwrite."
+                )
+                sd_card.set_loopdev(existing_loopdev)
+                sd_card.umount()
             # create empty disk image
             if not using_cached_step:
                 dtslogger.info(f"Creating empty disk image [{out_file_path('img')}]")

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -846,27 +846,33 @@ class DTCommand(DTCommandAbs):
                             with open(out_file_path("stats"), "wt") as fout:
                                 json.dump(stats, fout, indent=4, sort_keys=True)
                             run_cmd(["sudo", "cp", out_file_path("stats"), stats_filepath])
+                            host_resolv_conf = _host_resolv_conf_source()
+                            guest_resolv_conf = _guest_resolv_conf_target(ROOT_PARTITION)
                             # setup services
-                            run_cmd_in_partition(
-                                ROOT_PARTITION,
-                                "ln"
-                                " -s -f"
-                                " /etc/systemd/system/dt_init.service"
-                                " /etc/systemd/system/multi-user.target.wants/dt_init.service",
-                            )
-                                                        
-                            run_cmd_in_partition(
-                                ROOT_PARTITION,
-                                "curl -fsSL https://download.docker.com/linux/ubuntu/gpg  | sudo gpg " + 
-                                " --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
-                            )
-                            
-                            run_cmd_in_partition(
-                                ROOT_PARTITION,
-                                """echo "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
-                            https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-                            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null"""
-                            )
+                            _bind_mount(host_resolv_conf, guest_resolv_conf)
+                            try:
+                                run_cmd_in_partition(
+                                    ROOT_PARTITION,
+                                    "ln"
+                                    " -s -f"
+                                    " /etc/systemd/system/dt_init.service"
+                                    " /etc/systemd/system/multi-user.target.wants/dt_init.service",
+                                )
+
+                                run_cmd_in_partition(
+                                    ROOT_PARTITION,
+                                    "curl -fsSL https://download.docker.com/linux/ubuntu/gpg  | gpg "
+                                    " --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
+                                )
+
+                                run_cmd_in_partition(
+                                    ROOT_PARTITION,
+                                    """echo "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+                                https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+                                | tee /etc/apt/sources.list.d/docker.list > /dev/null"""
+                                )
+                            finally:
+                                _umount_if_mounted(guest_resolv_conf)
 
                         # flush I/O buffer
                         dtslogger.info("Flushing I/O buffer...")

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -8,6 +8,7 @@ import argparse
 import pathlib
 import json
 import os
+import platform
 import shutil
 import subprocess
 import time
@@ -46,6 +47,7 @@ from disk_image.create.utils import (
     list_files,
     copy_file,
     get_validator_fcn,
+    wait_for_disk,
 )
 
 MODULES_TO_LOAD = [
@@ -495,12 +497,12 @@ class DTCommand(DTCommandAbs):
                 f") | sudo fdisk {sd_card.loopdev}",
                 shell=True
             )
+            run_cmd(["sudo", "partprobe", sd_card.loopdev])
+            wait_for_disk(config_device, timeout=20)
             # make file system (FAT32 and 4096 bytes of block size (needed for comfortable surgery))
             run_cmd(["sudo", "mkfs", "-t", "fat", "-F", "32", "-S", "4096", config_device])
             # label file system
             run_cmd(["sudo", "fatlabel", config_device, CONFIG_PARTITION])
-            # force reload partitions
-            run_cmd(["sudo", "partprobe"])
             # show info about disk
             dtslogger.debug("\n" + run_cmd(["sudo", "fdisk", "-l", sd_card.loopdev], True))
             # ---
@@ -525,25 +527,30 @@ class DTCommand(DTCommandAbs):
                     raise ValueError(f"Disk device {root_partition_disk} not found")
                 # mount `root` partition
                 sd_card.mount_partition(ROOT_PARTITION)
+                host_machine = platform.machine()
+                host_machine = host_machine.lower()
+                host_runs_arm64_natively = host_machine in {"aarch64", "arm64"}
+                _dev = os.path.join(PARTITION_MOUNTPOINT(ROOT_PARTITION), "dev")
                 # from this point on, if anything weird happens, unmount the `root` disk
                 try:
-                    # copy QEMU, resolvconf
-                    _transfer_file(ROOT_PARTITION, ["usr", "bin", "qemu-aarch64-static"])
+                    # copy QEMU only when the host cannot execute arm64 binaries natively
+                    if not host_runs_arm64_natively:
+                        _transfer_file(ROOT_PARTITION, ["usr", "bin", "qemu-aarch64-static"])
                     _transfer_file(ROOT_PARTITION, ["run", "systemd", "resolve", "stub-resolv.conf"])
                     # mount /dev from the host
-                    _dev = os.path.join(PARTITION_MOUNTPOINT(ROOT_PARTITION), "dev")
                     run_cmd(["sudo", "mount", "--bind", "/dev", _dev])
-                    # configure the kernel for QEMU
-                    run_cmd(
-                        [
-                            "docker",
-                            "run",
-                            "--rm",
-                            "--privileged",
-                            "multiarch/qemu-user-static:register",
-                            "--reset",
-                        ]
-                    )
+                    # configure the kernel for QEMU only for non-native hosts
+                    if not host_runs_arm64_natively:
+                        run_cmd(
+                            [
+                                "docker",
+                                "run",
+                                "--rm",
+                                "--privileged",
+                                "multiarch/qemu-user-static:register",
+                                "--reset",
+                            ]
+                        )
                     # try running a simple echo from the new chroot, if an error occurs, we need
                     # to check the QEMU configuration
                     try:
@@ -553,16 +560,25 @@ class DTCommand(DTCommandAbs):
                         if "Exec format error" in output:
                             raise Exception("Exec format error")
                     except (BaseException, subprocess.CalledProcessError) as e:
-                        dtslogger.error(
-                            "An error occurred while trying to run an ARM binary "
-                            "from the temporary chroot.\n"
-                            "This usually indicates a misconfiguration of QEMU "
-                            "on the host.\n"
-                            "Please, make sure that you have the packages "
-                            "'qemu-user-static' and 'binfmt-support' installed "
-                            "via APT.\n\n"
-                            "The full error is:\n\t%s" % str(e)
-                        )
+                        if host_runs_arm64_natively:
+                            dtslogger.error(
+                                "An error occurred while trying to run an ARM binary "
+                                "from the temporary chroot.\n"
+                                f"The current host reports architecture '{host_machine}', "
+                                "so the chroot was expected to run natively.\n\n"
+                                "The full error is:\n\t%s" % str(e)
+                            )
+                        else:
+                            dtslogger.error(
+                                "An error occurred while trying to run an ARM binary "
+                                "from the temporary chroot.\n"
+                                "This usually indicates a misconfiguration of QEMU "
+                                "on the host.\n"
+                                "Please, make sure that you have the packages "
+                                "'qemu-user-static' and 'binfmt-support' installed "
+                                "via APT.\n\n"
+                                "The full error is:\n\t%s" % str(e)
+                            )
                         exit(2)
                     # compile list of packages to hold
                     to_hold = " ".join(APT_PACKAGES_TO_HOLD)
@@ -594,11 +610,13 @@ class DTCommand(DTCommandAbs):
                         )                        
                     except Exception as e:
                         raise e
-                    # unomunt bind /dev
-                    run_cmd(["sudo", "umount", _dev])
                 except Exception as e:
+                    if os.path.ismount(_dev):
+                        run_cmd(["sudo", "umount", _dev])
                     sd_card.umount_partition(ROOT_PARTITION)
                     raise e
+                if os.path.ismount(_dev):
+                    run_cmd(["sudo", "umount", _dev])
                 # unmount ROOT_PARTITION
                 sd_card.umount_partition(ROOT_PARTITION)
                 # ---

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -423,7 +423,9 @@ class DTCommand(DTCommandAbs):
                 if not granted:
                     dtslogger.info("Aborting.")
                     return
-            existing_loopdev = VirtualSDCard.find_loopdev(out_file_path("img"), quiet=True)
+            existing_loopdev = VirtualSDCard.find_loopdev(
+                out_file_path("img"), quiet=True, include_deleted=True
+            )
             if existing_loopdev:
                 dtslogger.warning(
                     f"The destination file {out_file_path('img')} is still mounted to {existing_loopdev}. "

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -423,6 +423,14 @@ class DTCommand(DTCommandAbs):
                 if not granted:
                     dtslogger.info("Aborting.")
                     return
+            existing_loopdev = VirtualSDCard.find_loopdev(out_file_path("img"), quiet=True)
+            if existing_loopdev:
+                dtslogger.warning(
+                    f"The destination file {out_file_path('img')} is still mounted to {existing_loopdev}. "
+                    "Detaching it before overwrite."
+                )
+                sd_card.set_loopdev(existing_loopdev)
+                sd_card.umount()
             # create empty disk image
             if not using_cached_step:
                 dtslogger.info(f"Creating empty disk image [{out_file_path('img')}]")

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -76,6 +76,7 @@ DEFAULT_STACK = "robot"
 DISK_IMAGE_PARTITION_TABLE = {"bootfs": 1, "rootfs": 2, "configfs": 3}
 DISK_IMAGE_PARTITION_MOUNTPOINT = {"bootfs": "/boot", "rootfs": "/", "configfs": "/config"}
 AVAILABLE_STACKS_DIR = "/data/stacks/available"
+BOOT_PARTITION = "bootfs"
 ROOT_PARTITION = "rootfs"
 CONFIG_PARTITION = "configfs"
 DEFAULT_HOSTNAME = "robot"
@@ -125,6 +126,53 @@ APT_PACKAGES_TO_HOLD = [
     # list here packages that cannot be updated through `chroot`
     # "initramfs-tools"
 ]
+
+
+def _host_resolv_conf_source():
+    candidates = [
+        "/run/systemd/resolve/resolv.conf",
+        "/etc/resolv.conf",
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate) and os.path.getsize(candidate) > 0:
+            return candidate
+    raise FileNotFoundError("Could not find a usable host resolv.conf file.")
+
+
+def _guest_path(partition, *parts):
+    return os.path.join(PARTITION_MOUNTPOINT(partition), *parts)
+
+
+def _guest_resolv_conf_target(partition):
+    guest_resolv_conf = _guest_path(partition, "etc", "resolv.conf")
+    if os.path.islink(guest_resolv_conf):
+        guest_resolv_conf = os.path.realpath(guest_resolv_conf)
+    guest_resolv_dir = os.path.dirname(guest_resolv_conf)
+    run_cmd(["sudo", "mkdir", "-p", guest_resolv_dir])
+    if not os.path.exists(guest_resolv_conf):
+        run_cmd(["sudo", "touch", guest_resolv_conf])
+    return guest_resolv_conf
+
+
+def _bind_mount(source, target):
+    target_dir = os.path.dirname(target)
+    run_cmd(["sudo", "mkdir", "-p", target_dir])
+    if not os.path.exists(target):
+        if os.path.isdir(source):
+            run_cmd(["sudo", "mkdir", "-p", target])
+        else:
+            run_cmd(["sudo", "touch", target])
+    run_cmd(["sudo", "mount", "--bind", source, target])
+
+
+def _umount_if_mounted(target):
+    if os.path.ismount(target):
+        run_cmd(["sudo", "umount", target])
+
+
+def _partition_is_mounted(partition):
+    mountpoint = PARTITION_MOUNTPOINT(partition)
+    return os.path.exists(mountpoint) and os.path.ismount(mountpoint)
 
 
 class DTCommand(DTCommandAbs):
@@ -525,20 +573,42 @@ class DTCommand(DTCommandAbs):
                 root_partition_disk = sd_card.partition_device(ROOT_PARTITION)
                 if not os.path.exists(root_partition_disk):
                     raise ValueError(f"Disk device {root_partition_disk} not found")
+                boot_partition_disk = sd_card.partition_device(BOOT_PARTITION)
+                if not os.path.exists(boot_partition_disk):
+                    raise ValueError(f"Disk device {boot_partition_disk} not found")
                 # mount `root` partition
                 sd_card.mount_partition(ROOT_PARTITION)
+                sd_card.mount_partition(BOOT_PARTITION)
                 host_machine = platform.machine()
                 host_machine = host_machine.lower()
                 host_runs_arm64_natively = host_machine in {"aarch64", "arm64"}
-                _dev = os.path.join(PARTITION_MOUNTPOINT(ROOT_PARTITION), "dev")
+                guest_dev = _guest_path(ROOT_PARTITION, "dev")
+                guest_dev_pts = _guest_path(ROOT_PARTITION, "dev", "pts")
+                guest_proc = _guest_path(ROOT_PARTITION, "proc")
+                guest_sys = _guest_path(ROOT_PARTITION, "sys")
+                guest_boot_firmware = _guest_path(ROOT_PARTITION, "boot", "firmware")
+                boot_partition_mountpoint = PARTITION_MOUNTPOINT(BOOT_PARTITION)
+                host_resolv_conf = _host_resolv_conf_source()
+                guest_resolv_conf = _guest_resolv_conf_target(ROOT_PARTITION)
+                mounted_targets = []
                 # from this point on, if anything weird happens, unmount the `root` disk
                 try:
                     # copy QEMU only when the host cannot execute arm64 binaries natively
                     if not host_runs_arm64_natively:
                         _transfer_file(ROOT_PARTITION, ["usr", "bin", "qemu-aarch64-static"])
-                    _transfer_file(ROOT_PARTITION, ["run", "systemd", "resolve", "stub-resolv.conf"])
+                    _bind_mount(host_resolv_conf, guest_resolv_conf)
+                    mounted_targets.append(guest_resolv_conf)
+                    _bind_mount(boot_partition_mountpoint, guest_boot_firmware)
+                    mounted_targets.append(guest_boot_firmware)
+                    _bind_mount("/proc", guest_proc)
+                    mounted_targets.append(guest_proc)
+                    _bind_mount("/sys", guest_sys)
+                    mounted_targets.append(guest_sys)
                     # mount /dev from the host
-                    run_cmd(["sudo", "mount", "--bind", "/dev", _dev])
+                    _bind_mount("/dev", guest_dev)
+                    mounted_targets.append(guest_dev)
+                    _bind_mount("/dev/pts", guest_dev_pts)
+                    mounted_targets.append(guest_dev_pts)
                     # configure the kernel for QEMU only for non-native hosts
                     if not host_runs_arm64_natively:
                         run_cmd(
@@ -606,17 +676,21 @@ class DTCommand(DTCommandAbs):
                         # clean packages
                         run_cmd_in_partition(
                             ROOT_PARTITION,
-                            f"apt autoremove --yes",
+                            "apt autoremove --yes",
                         )                        
                     except Exception as e:
                         raise e
                 except Exception as e:
-                    if os.path.ismount(_dev):
-                        run_cmd(["sudo", "umount", _dev])
+                    for target in reversed(mounted_targets):
+                        _umount_if_mounted(target)
+                    if _partition_is_mounted(BOOT_PARTITION):
+                        sd_card.umount_partition(BOOT_PARTITION)
                     sd_card.umount_partition(ROOT_PARTITION)
                     raise e
-                if os.path.ismount(_dev):
-                    run_cmd(["sudo", "umount", _dev])
+                for target in reversed(mounted_targets):
+                    _umount_if_mounted(target)
+                if _partition_is_mounted(BOOT_PARTITION):
+                    sd_card.umount_partition(BOOT_PARTITION)
                 # unmount ROOT_PARTITION
                 sd_card.umount_partition(ROOT_PARTITION)
                 # ---

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -27,6 +27,7 @@ from disk_image.create.constants import (
     DISK_IMAGE_STATS_LOCATION,
     DOCKER_IMAGE_TEMPLATE,
     DATA_STORAGE_DISK_IMAGE_DIR,
+    MODULES_TO_LOAD as DEFAULT_MODULES_TO_LOAD,
 )
 
 from disk_image.create.utils import (
@@ -50,10 +51,13 @@ from disk_image.create.utils import (
     wait_for_disk,
 )
 
-MODULES_TO_LOAD = [
-    {"owner": "duckietown", "module": "portainer"},
-    {"owner": "duckietown", "module": "dt-kvstore", "tag": "v0.2.0-arm64v8"},
-]
+MODULES_TO_LOAD = []
+for module in DEFAULT_MODULES_TO_LOAD:
+    module_to_load = dict(module)
+    if module_to_load["module"] == "dt-kvstore":
+        module_to_load["tag"] = "ente"
+    MODULES_TO_LOAD.append(module_to_load)
+
 DEFAULT_STACK = "robot"
 
 # NOTE: -----------------------------------

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -715,9 +715,9 @@ class DTCommand(DTCommandAbs):
                 STACKS_BASE_DIR=STACKS_BASE_DIR,
                 DEVICE_PLATFORM="linux/arm64",
                 DIND_IMAGE_NAME="docker:20.10.5-dind",
-                cache_step_fn=cache_step,
                 architecture="arm64v8",
             )
+            cache_step("docker")
             dtslogger.info("Step END: docker\n")
             
         # ------>

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -500,7 +500,7 @@ class DTCommand(DTCommandAbs):
             run_cmd(["sudo", "partprobe", sd_card.loopdev])
             wait_for_disk(config_device, timeout=20)
             # make file system (FAT32 and 4096 bytes of block size (needed for comfortable surgery))
-            run_cmd(["sudo", "mkfs", "-t", "fat", "-F", "32", "-S", "4096", config_device])
+            run_cmd(["sudo", "mkfs.fat", "-F", "32", "-S", "4096", config_device])
             # label file system
             run_cmd(["sudo", "fatlabel", config_device, CONFIG_PARTITION])
             # show info about disk

--- a/disk_image/create/raspberry_pi_arm64v8/private_command.py
+++ b/disk_image/create/raspberry_pi_arm64v8/private_command.py
@@ -753,7 +753,7 @@ class DTCommand(DTCommandAbs):
                         raise ValueError(f"Partition {partition} not declared in partition table")
                     # check if the corresponding disk device exists
                     partition_disk = sd_card.partition_device(partition)
-                    if not os.path.exists(partition_disk):
+                    if not wait_for_disk(partition_disk, timeout=20):
                         raise ValueError(f"Disk device {partition_disk} not found")
                     # mount device
                     sd_card.mount_partition(partition)

--- a/disk_image/create/steps.py
+++ b/disk_image/create/steps.py
@@ -5,7 +5,7 @@ import time
 from typing import Set
 import yaml
 import docker
-from disk_image.create.utils import VirtualSDCard
+from disk_image.create.utils import VirtualSDCard, pull_docker_image
 from disk_image.create.constants import PARTITION_MOUNTPOINT, DATA_STORAGE_DISK_IMAGE_DIR
 from types import SimpleNamespace
 
@@ -105,8 +105,7 @@ def step_docker(
             local_docker.images.get(DIND_IMAGE_NAME)
             dtslogger.debug(f"DIND image `{DIND_IMAGE_NAME}` already present locally.")
         except docker.errors.ImageNotFound:
-            dtslogger.info(f"Pulling DIND image `{DIND_IMAGE_NAME}`…")
-            local_docker.images.pull(DIND_IMAGE_NAME)
+            pull_docker_image(local_docker, DIND_IMAGE_NAME)
 
         remote_docker_dir = os.path.join(
             PARTITION_MOUNTPOINT(ROOT_PARTITION), "var", "lib", "docker"
@@ -157,9 +156,8 @@ def step_docker(
         if all_stack_images:
             dtslogger.info(f"Transferring {len(all_stack_images)} Docker images into the disk…")
             for img_name in sorted(all_stack_images):
-                dtslogger.info(f"  · Pulling {img_name}…")
                 try:
-                    remote_docker.images.pull(img_name, platform=DEVICE_PLATFORM)
+                    pull_docker_image(remote_docker, img_name, platform=DEVICE_PLATFORM)
                 except Exception as e:
                     dtslogger.warning(f"    ↳ failed to pull {img_name}: {e}")
             dtslogger.info("Finished transferring all stack images.")

--- a/disk_image/create/utils.py
+++ b/disk_image/create/utils.py
@@ -92,7 +92,8 @@ class VirtualSDCard:
             output = subprocess.check_output(cmd).decode("utf-8")
             devices = json.loads(output)
             for dev in devices["loopdevices"]:
-                if "(deleted)" in dev["back-file"] or dev["back-file"].split(" ")[0] != self._disk_file:
+                back_file, _ = _loop_back_file_info(dev["back-file"])
+                if back_file != self._disk_file:
                     continue
                 if not quiet:
                     dtslogger.info(f"Unmounting {self._disk_file} from {dev['name']}...")
@@ -228,7 +229,7 @@ class VirtualSDCard:
         return None
 
     @staticmethod
-    def find_loopdev(disk_file, quiet=False):
+    def find_loopdev(disk_file, quiet=False, include_deleted=False):
         # mount loop device
         if not quiet:
             dtslogger.info(f"Looking for loop devices associated to disk image {disk_file}...")
@@ -236,7 +237,11 @@ class VirtualSDCard:
             # iterate over loop devices
             lodevices = json.loads(run_cmd(["sudo", "losetup", "--json"], get_output=True))
             for dev in lodevices["loopdevices"]:
-                if dev["back-file"].split(" ")[0] == disk_file:
+                back_file, is_deleted = _loop_back_file_info(dev["back-file"])
+                if back_file != disk_file:
+                    continue
+                if is_deleted and not include_deleted:
+                    continue
                     if not quiet:
                         dtslogger.info(f"Found {dev['name']}!")
                     # found a loop device connected to the given image
@@ -473,6 +478,14 @@ def ensure_block_device_node(disk):
         os.makedirs(disk_dir, exist_ok=True)
     run_cmd(["sudo", "mknod", disk, "b", str(device_major), str(device_minor)])
     return os.path.exists(disk)
+
+
+def _loop_back_file_info(back_file):
+    deleted_suffix = " (deleted)"
+    is_deleted = back_file.endswith(deleted_suffix)
+    if is_deleted:
+        back_file = back_file[: -len(deleted_suffix)]
+    return back_file, is_deleted
 
 
 def _loop_partition_sysfs_device_path(disk):

--- a/disk_image/create/utils.py
+++ b/disk_image/create/utils.py
@@ -165,6 +165,7 @@ class VirtualSDCard:
             raise ValueError(msg)
         # wait for the device to be free
         in_use = True
+        wait_cycles = 0
         while in_use:
             dtslogger.info(f"Waiting for [{partition_device}]{mountpoint} to be freed.")
             time.sleep(2)
@@ -172,6 +173,24 @@ class VirtualSDCard:
                 ["sudo", "lsof", partition_device, "2>/dev/null", "||", ":"], get_output=True, shell=True
             ).splitlines()
             in_use = len(lsof) > 0
+            if not in_use:
+                break
+            wait_cycles += 1
+            if wait_cycles < 5:
+                continue
+            pids = _lsof_mountpoint_pids(lsof, mountpoint)
+            if not pids:
+                continue
+            signal = "-9" if wait_cycles >= 8 else None
+            action = "SIGKILL" if signal else "SIGTERM"
+            dtslogger.warning(
+                f"Processes are still using {mountpoint}; sending {action} to: {', '.join(pids)}"
+            )
+            kill_cmd = ["sudo", "kill"]
+            if signal:
+                kill_cmd.append(signal)
+            kill_cmd.extend(pids)
+            run_cmd(kill_cmd)
         # unmount
         run_cmd(["sudo", "umount", mountpoint])
         run_cmd(["sudo", "rmdir", mountpoint])
@@ -263,6 +282,19 @@ def check_cli_tools(*args):
     clis = CLI_TOOLS_NEEDED + list(args)
     for cli_tool in clis:
         ensure_command_is_installed(cli_tool)
+
+
+def _lsof_mountpoint_pids(lines: List[str], mountpoint: str) -> List[str]:
+    pids = set()
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        pid = parts[1]
+        path = parts[-1]
+        if pid.isdigit() and path.startswith(mountpoint):
+            pids.add(pid)
+    return sorted(pids)
 
 
 def pull_docker_image(client, image, platform=None):

--- a/disk_image/create/utils.py
+++ b/disk_image/create/utils.py
@@ -115,6 +115,16 @@ class VirtualSDCard:
         # check if the mountpoint exists
         if os.path.exists(mountpoint):
             if os.path.ismount(mountpoint):
+                mounted_source = run_cmd(
+                    ["findmnt", "-n", "-o", "SOURCE", "--target", mountpoint],
+                    get_output=True,
+                ).strip()
+                same_device = mounted_source == partition_device
+                if not same_device and os.path.exists(mounted_source) and os.path.exists(partition_device):
+                    same_device = os.stat(mounted_source).st_rdev == os.stat(partition_device).st_rdev
+                if same_device:
+                    dtslogger.info(f'Partition "{partition}" already mounted, reusing it.')
+                    return
                 msg = f"The directory {mountpoint} is already mounted."
                 dtslogger.error(msg)
                 raise ValueError(msg)

--- a/disk_image/create/utils.py
+++ b/disk_image/create/utils.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import time
@@ -23,6 +24,7 @@ from disk_image.create.constants import (
     MODULES_TO_LOAD,
     PARTITION_MOUNTPOINT,
     DEFAULT_STACK,
+    TMP_WORKDIR,
 )
 from utils.cli_utils import ensure_command_is_installed
 from utils.misc_utils import sudo_open, indent_block
@@ -40,10 +42,12 @@ class VirtualSDCard:
         return self._loopdev
 
     def set_loopdev(self, loopdev):
+        if self._loopdev is not None and self._loopdev != loopdev:
+            self._cleanup_partition_devices()
         self._loopdev = loopdev
 
     def partition_device(self, partition):
-        return f"{self._loopdev}p{self._partition_table[partition]}"
+        return self._disk_by_label(partition)
 
     def is_mounted(self):
         return self._loopdev is not None
@@ -75,7 +79,7 @@ class VirtualSDCard:
         # refresh devices module
         run_cmd(["sudo", "udevadm", "trigger"])
         # once mounted, keep track of the loopdev in use
-        self._loopdev = lodev
+        self.set_loopdev(lodev)
 
     def umount(self, quiet=False):
         # mount loop device
@@ -96,6 +100,8 @@ class VirtualSDCard:
         except Exception as e:
             if not quiet:
                 raise e
+        self._cleanup_partition_devices()
+        self._loopdev = None
         if not quiet:
             dtslogger.info("Done!")
         # refresh devices module
@@ -207,8 +213,30 @@ class VirtualSDCard:
         if self._loopdev:
             if partition not in self._partition_table:
                 raise KeyError(f"Partition '{partition}' not found in the partition table")
-            return f"{self._loopdev}p{self._partition_table[partition]}"
+            loop_partition_device = self._loop_partition_device(partition)
+            if os.path.exists(loop_partition_device):
+                return loop_partition_device
+            fallback_partition_device = self._fallback_partition_device(partition)
+            ensure_block_device_node(fallback_partition_device)
+            return fallback_partition_device
         return f"/dev/disk/by-label/{partition}"
+
+    def _loop_partition_device(self, partition):
+        partition_id = self._partition_table[partition]
+        return f"{self._loopdev}p{partition_id}"
+
+    def _fallback_partition_device(self, partition):
+        loop_partition_device = self._loop_partition_device(partition)
+        device_name = os.path.basename(loop_partition_device)
+        return os.path.join(TMP_WORKDIR, "devices", device_name)
+
+    def _cleanup_partition_devices(self):
+        if self._loopdev is None:
+            return
+        for partition in self._partition_table:
+            fallback_partition_device = self._fallback_partition_device(partition)
+            if os.path.lexists(fallback_partition_device):
+                run_cmd(["sudo", "rm", "-f", fallback_partition_device])
 
 
 def check_cli_tools(*args):
@@ -352,8 +380,62 @@ def run_cmd_in_partition(partition, cmd, *args, **kwargs):
 
 def wait_for_disk(disk, timeout):
     stime = time.time()
-    while (time.time() - stime < timeout) and (not os.path.exists(disk)):
+    while time.time() - stime < timeout:
+        if ensure_block_device_node(disk):
+            return True
+        if os.path.exists(disk):
+            return True
         time.sleep(1.0)
+    if ensure_block_device_node(disk):
+        return True
+    return os.path.exists(disk)
+
+
+def ensure_block_device_node(disk):
+    sysfs_device_path = _loop_partition_sysfs_device_path(disk)
+    if sysfs_device_path is None:
+        return os.path.exists(disk)
+
+    if not os.path.exists(sysfs_device_path):
+        if _is_managed_block_device_node(disk) and os.path.lexists(disk):
+            run_cmd(["sudo", "rm", "-f", disk])
+        return False
+
+    with open(sysfs_device_path, "rt") as fin:
+        device_numbers = fin.read().strip()
+    major_str, minor_str = device_numbers.split(":")
+    device_major = int(major_str)
+    device_minor = int(minor_str)
+
+    if os.path.exists(disk):
+        disk_stat = os.stat(disk)
+        is_block_device = stat.S_ISBLK(disk_stat.st_mode)
+        current_major = os.major(disk_stat.st_rdev)
+        current_minor = os.minor(disk_stat.st_rdev)
+        if is_block_device and current_major == device_major and current_minor == device_minor:
+            return True
+        run_cmd(["sudo", "rm", "-f", disk])
+
+    disk_dir = os.path.dirname(disk)
+    if len(disk_dir):
+        os.makedirs(disk_dir, exist_ok=True)
+    run_cmd(["sudo", "mknod", disk, "b", str(device_major), str(device_minor)])
+    return os.path.exists(disk)
+
+
+def _loop_partition_sysfs_device_path(disk):
+    disk_name = os.path.basename(disk)
+    if re.fullmatch(r"loop\d+p\d+", disk_name) is None:
+        return None
+    return os.path.join("/sys/class/block", disk_name, "dev")
+
+
+def _is_managed_block_device_node(disk):
+    managed_dir = os.path.join(TMP_WORKDIR, "devices")
+    managed_dir = os.path.abspath(managed_dir)
+    disk_path = os.path.abspath(disk)
+    managed_prefix = managed_dir + os.sep
+    return disk_path.startswith(managed_prefix)
 
 
 def get_validator_fcn(validators, partition, path):

--- a/disk_image/create/utils.py
+++ b/disk_image/create/utils.py
@@ -114,13 +114,23 @@ class VirtualSDCard:
         mountpoint = PARTITION_MOUNTPOINT(partition)
         # check if the mountpoint exists
         if os.path.exists(mountpoint):
-            msg = f"The directory {mountpoint} already exists. Remove it before continuing."
-            dtslogger.error(msg)
-            raise ValueError(msg)
+            if os.path.ismount(mountpoint):
+                msg = f"The directory {mountpoint} is already mounted."
+                dtslogger.error(msg)
+                raise ValueError(msg)
+            if not os.path.isdir(mountpoint):
+                msg = f"The path {mountpoint} exists and is not a directory."
+                dtslogger.error(msg)
+                raise ValueError(msg)
+            if os.listdir(mountpoint):
+                msg = f"The directory {mountpoint} already exists and is not empty. Remove it before continuing."
+                dtslogger.error(msg)
+                raise ValueError(msg)
         # mount partition
         wait_for_disk(partition_device, timeout=20)
         try:
-            run_cmd(["sudo", "mkdir", "-p", mountpoint])
+            if not os.path.exists(mountpoint):
+                run_cmd(["sudo", "mkdir", "-p", mountpoint])
             run_cmd(["sudo", "mount", "-t", "auto", partition_device, mountpoint])
         except BaseException as e:
             dtslogger.error(f'We had issues mounting partition "{partition}".')

--- a/utils/cli_utils.py
+++ b/utils/cli_utils.py
@@ -9,6 +9,12 @@ from dt_shell import dtslogger, UserError
 __all__ = ["get_clean_env", "start_command_in_subprocess", "ask_confirmation", "ensure_command_is_installed"]
 
 
+COMMAND_INSTALL_PACKAGES = {
+    "mkfs.fat": "dosfstools",
+    "fatlabel": "dosfstools",
+}
+
+
 def get_clean_env():
     env = {}
     env.update(os.environ)
@@ -82,9 +88,18 @@ def ensure_command_is_installed(command, dependant: Optional[str] = None):
         extra: str = ""
         if dependant:
             extra = f" by '{dependant}'"
+        package: Optional[str] = COMMAND_INSTALL_PACKAGES.get(command)
+        install_hint: str
+        if package is None:
+            install_hint = "Please, install it before continuing."
+        else:
+            install_hint = (
+                f"Install the package '{package}' and retry "
+                f"(for Debian/Ubuntu: sudo apt install -y {package})."
+            )
         msg = f"""
 
-        The command '{command}' is required{extra}. Please, install it before continuing.
+        The command '{command}' is required{extra}. {install_hint}
 
         """
         raise UserError(msg)


### PR DESCRIPTION
This pull request updates how the temporary working directory (`TMP_WORKDIR`) is determined in the `disk_image/create/constants.py` file. Instead of using a hardcoded path, the code now dynamically selects a writable directory, improving compatibility across different environments.

Temporary work directory improvements:

* Added logic to select `TMP_WORKDIR` by checking both a legacy path (`/tmp/duckietown/dts/disk_image`) and a fallback path in the user's home directory (`~/.cache/duckietown/dts/disk_image`), ensuring that the directory is writable before selecting it.
* Introduced helper functions `_get_existing_parent_dir` and `_can_create_workdir` to robustly determine if a directory can be created and used.

Constants and compatibility:

* Renamed the original `TMP_WORKDIR` constant to `LEGACY_TMP_WORKDIR` and added `FALLBACK_TMP_WORKDIR` and `HOME_DIR` constants for clarity and future compatibility.