### PR TITLE
DTSW-8043-dts-init_sd_card-does-not-work-correctly-on-macOS

### DIFF
--- a/init_sd_card/command.py
+++ b/init_sd_card/command.py
@@ -665,6 +665,13 @@ def step_setup(shell: DTShell, parsed: argparse.Namespace, data: dict):
     ensure_command_is_installed("dd")
     ensure_command_is_installed("sudo")
     ensure_command_is_installed("sync")
+    is_sd_target = parsed.device is not None and parsed.device.startswith("/dev/")
+    if is_sd_target:
+        dtslogger.info(f"Unmounting device {parsed.device} before applying setup data...")
+        _unmount_device(parsed.device)
+        if platform.system() == "Darwin":
+            time.sleep(0.5)
+    target_device = parsed.device
     # make a copy of the command parameters and remove wifi passwords
     params = copy.deepcopy(parsed.__dict__)
     wfstr = lambda w: w if ":" not in w else (w.split(":")[0] + ":***")
@@ -760,9 +767,9 @@ def step_setup(shell: DTShell, parsed: argparse.Namespace, data: dict):
             + "into [{partition}]:{path}.".format(**surgery_bit)
         )
         # apply change
-        dd_cmd = (["sudo"] if data.get("sd_type", "SD") == "SD" else []) + [
+        dd_cmd = (["sudo"] if is_sd_target else []) + [
             "dd",
-            "of={}".format(parsed.device),
+            "of={}".format(target_device),
             "bs=1",
             "count={}".format(block_size),
             "seek={}".format(block_offset),
@@ -770,14 +777,34 @@ def step_setup(shell: DTShell, parsed: argparse.Namespace, data: dict):
         ]
         # write twice (found to increase success rate)
         for wpass in range(2):
-            # launch dd
-            dd = subprocess.Popen(dd_cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-            dtslogger.debug(f"[{wpass + 1}/2] $ {dd_cmd}")
-            # write
-            dd.stdin.write(masked_content)
-            dd.stdin.flush()
-            dd.stdin.close()
-            dd.wait()
+            retries = 10 if is_sd_target and platform.system() == "Darwin" else 1
+            for attempt in range(retries):
+                if is_sd_target:
+                    _unmount_device(parsed.device)
+                    if platform.system() == "Darwin":
+                        time.sleep(0.5)
+                # launch dd
+                dd = subprocess.Popen(dd_cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+                dtslogger.debug(f"[{wpass + 1}/2] $ {dd_cmd}")
+                _, stderr = dd.communicate(masked_content)
+                if dd.returncode == 0:
+                    break
+                error = stderr.decode("utf-8", errors="replace").strip()
+                can_retry = (
+                    platform.system() == "Darwin"
+                    and "Resource busy" in error
+                    and attempt + 1 < retries
+                )
+                if can_retry:
+                    dtslogger.warning(
+                        f"Write target {target_device} is busy, retrying "
+                        f"({attempt + 1}/{retries})..."
+                    )
+                    time.sleep(0.5)
+                    continue
+                raise RuntimeError(
+                    f"Failed to inject placeholder {surgery_bit['placeholder']} into {target_device}: {error}"
+                )
             # flush I/O buffer
             _run_cmd(["sync"])
     dtslogger.info("Surgery went OK!")

--- a/init_sd_card/command.py
+++ b/init_sd_card/command.py
@@ -58,7 +58,7 @@ DEFAULT_WIFI_CONFIG = "duckietown:quackquack"
 COMMAND_DIR = os.path.dirname(os.path.abspath(__file__))
 SUPPORTED_STEPS = ["license", "download", "flash", "setup"]
 NVIDIA_LICENSE_FILE = os.path.join(COMMAND_DIR, "nvidia-license.txt")
-ROOT_PARTITIONS = ["root", "APP"]
+ROOT_PARTITIONS = ["root", "rootfs", "APP"]
 
 
 def DISK_IMAGE_VERSION(robot_configuration, experimental=False, version_override=None):


### PR DESCRIPTION
This pull request enhances the robustness of the SD card setup process, particularly when writing to SD card devices on macOS. The main improvements include better handling of device unmounting, retries for busy devices, and expanded support for root partitions.

**Improvements to SD card writing reliability:**

* The setup process now attempts to unmount the SD card device (`parsed.device`) before applying setup data, with an additional delay on macOS to ensure the device is released.
* When writing data with `dd`, the code now retries up to 10 times if the device is busy on macOS, logging warnings and waiting between attempts. This addresses the common "Resource busy" error on macOS SD card writes.

**Partition and command changes:**

* The list of recognized root partitions now includes `rootfs` in addition to `root` and `APP`, improving compatibility with different partition naming conventions.
* The logic for when to use `sudo` with `dd` has been updated to depend on whether the target is an SD card device, rather than the `sd_type` field.
* The device path is now consistently referenced through a new `target_device` variable, improving clarity and maintainability. [[1]](diffhunk://#diff-a8c508dea591bbc24eb7c1a16df85370b67735e3bd6298cad7bffa9bec5de43bR668-R674) [[2]](diffhunk://#diff-a8c508dea591bbc24eb7c1a16df85370b67735e3bd6298cad7bffa9bec5de43bL763-R807)