### PR TITLE
DTSW-8056-Add-the-ability-to-stream-a-robot-s-startup-logs

### DIFF
--- a/command_descriptions.yaml
+++ b/command_descriptions.yaml
@@ -158,6 +158,8 @@ duckiebot:
   subcommands:
     _update:
       description: Update the code API for a DT robot
+    startup_logs:
+      description: Stream a DT robot's startup logs
     battery:
       description: DT robot battery commands
       subcommands:

--- a/duckiebot/startup_logs/command.py
+++ b/duckiebot/startup_logs/command.py
@@ -1,0 +1,24 @@
+import argparse
+
+from dt_shell import DTCommandAbs, DTShell, dtslogger
+
+from .common import stream_startup_logs
+
+
+class DTCommand(DTCommandAbs):
+    help = "Streams a DT robot's startup logs"
+
+    @staticmethod
+    def command(shell: DTShell, args):
+        prog = "dts duckiebot startup_logs"
+        parser = argparse.ArgumentParser(prog=prog)
+        parser.add_argument("robot", nargs=1, help="Name of the robot to inspect")
+        parsed = parser.parse_args(args)
+        robot_name = parsed.robot[0]
+        dtslogger.info(f"Streaming startup logs for '{robot_name}'...")
+        try:
+            stream_startup_logs(robot_name)
+        except KeyboardInterrupt:
+            dtslogger.info("Stopped streaming startup logs.")
+        except Exception as error:
+            dtslogger.error(str(error))

--- a/duckiebot/startup_logs/common.py
+++ b/duckiebot/startup_logs/common.py
@@ -1,0 +1,197 @@
+import os
+import shlex
+import subprocess
+import sys
+import tarfile
+from datetime import datetime
+from io import BytesIO
+
+import docker as dockerpy
+
+from utils.cli_utils import ensure_command_is_installed
+from utils.networking_utils import is_local_virtual_robot_running
+from utils.resolve import resolve_robot_host
+
+SSH_USERNAME = "duckie"
+STARTUP_LOG_FILES = ("/data/logs/first_boot_init.log", "/data/logs/this_boot_init.log")
+STARTUP_LOG_POLL_INTERVAL_SECONDS = 0.1
+STARTUP_LOG_COMPLETION_MARKERS = (
+    "Setting up completed!",
+    "Robot configured!",
+)
+STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH = "/tmp/dts-startup-log-stream.py"
+STARTUP_LOG_STREAM_SCRIPT_HOST_PATH = os.path.join(os.path.dirname(__file__), "startup_log_stream.py")
+
+
+def stream_startup_logs(robot_name, startup_started_at=None):
+    normalized_robot_name = robot_name[:-6] if robot_name.endswith(".local") else robot_name
+    if is_local_virtual_robot_running(normalized_robot_name):
+        stream_local_virtual_robot_startup_logs(
+            normalized_robot_name,
+            startup_started_at=startup_started_at,
+        )
+        return
+    stream_remote_robot_startup_logs(robot_name, startup_started_at=startup_started_at)
+
+
+def stream_local_virtual_robot_startup_logs(robot_name, startup_started_at=None, local_docker=None):
+    docker_client = local_docker
+    if docker_client is None:
+        docker_client = dockerpy.from_env()
+    container_name = f"dts-virtual-{robot_name}"
+    container = docker_client.containers.get(container_name)
+    if startup_started_at is None:
+        startup_started_at = _get_container_started_at(container)
+    try:
+        if not _copy_startup_log_stream_script(container):
+            return
+        result = container.exec_run(
+            [
+                "python3",
+                STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH,
+                "--startup-started-at",
+                str(int(startup_started_at)),
+                "--poll-interval",
+                str(STARTUP_LOG_POLL_INTERVAL_SECONDS),
+                *_completion_marker_args(),
+                *STARTUP_LOG_FILES,
+            ],
+            stderr=False,
+            stream=True,
+        )
+    except dockerpy.errors.APIError as error:
+        raise RuntimeError(str(error)) from error
+    output_stream = result.output if hasattr(result, "output") else result[1]
+    if output_stream is None:
+        return
+    pending_fragment = ""
+    for chunk in output_stream:
+        normalized_chunk = _normalize_exec_output_chunk(chunk)
+        if not normalized_chunk:
+            continue
+        pending_fragment = _log_output_lines(normalized_chunk, pending_fragment)
+    if pending_fragment.strip():
+        message = pending_fragment.rstrip()
+        print(message)
+
+
+def stream_remote_robot_startup_logs(robot_name, startup_started_at=None):
+    hostname = resolve_robot_host(robot_name)
+    if startup_started_at is None:
+        startup_started_at = _get_remote_boot_started_at(hostname)
+    ensure_command_is_installed("ssh", dependant="dts duckiebot startup_logs")
+    remote_args = [
+        "python3",
+        "-",
+        "--startup-started-at",
+        str(int(startup_started_at)),
+        "--poll-interval",
+        str(STARTUP_LOG_POLL_INTERVAL_SECONDS),
+        *_completion_marker_args(),
+        *STARTUP_LOG_FILES,
+    ]
+    command = _ssh_remote_command(hostname, remote_args)
+    with open(STARTUP_LOG_STREAM_SCRIPT_HOST_PATH, "rb") as script_file:
+        result = subprocess.run(
+            command,
+            stdin=script_file,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=False,
+        )
+    if result.returncode not in [0, 130]:
+        raise RuntimeError(
+            f"Failed to stream startup logs from '{robot_name}' ({hostname}). "
+            f"The ssh command exited with code {result.returncode}."
+        )
+
+
+def _copy_startup_log_stream_script(container):
+    archive = BytesIO()
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        arcname = os.path.basename(STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH)
+        tar.add(STARTUP_LOG_STREAM_SCRIPT_HOST_PATH, arcname=arcname)
+    archive.seek(0)
+    path = os.path.dirname(STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH)
+    return container.put_archive(path=path, data=archive)
+
+
+def _get_container_started_at(container):
+    started_at = container.attrs.get("State", {}).get("StartedAt", "")
+    if not started_at:
+        raise RuntimeError(f"Unable to determine when container '{container.name}' started.")
+    return int(datetime.fromisoformat(started_at.replace("Z", "+00:00")).timestamp())
+
+
+def _get_remote_boot_started_at(hostname):
+    ensure_command_is_installed("ssh", dependant="dts duckiebot startup_logs")
+    remote_args = [
+        "python3",
+        "-c",
+        "import time; print(int(time.time() - float(open('/proc/uptime').read().split()[0])))",
+    ]
+    command = _ssh_remote_command(hostname, remote_args)
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(
+            f"Failed to determine the boot time for robot host '{hostname}'. {stderr}"
+        )
+    stdout = result.stdout.strip()
+    if not stdout:
+        raise RuntimeError(f"Robot host '{hostname}' returned an empty boot time.")
+    try:
+        return int(stdout)
+    except ValueError as error:
+        raise RuntimeError(
+            f"Robot host '{hostname}' returned an invalid boot time: '{stdout}'."
+        ) from error
+
+
+def _log_output_lines(chunk, pending_fragment):
+    lines = f"{pending_fragment}{chunk}".replace("\r", "\n")
+    lines = lines.split("\n")
+    pending_fragment = lines.pop()
+    for line in lines:
+        if line.strip():
+            message = line.rstrip()
+            print(message)
+    return pending_fragment
+
+
+def _normalize_exec_output_chunk(chunk):
+    if isinstance(chunk, tuple):
+        chunk = b"".join(part for part in chunk if part)
+    if not chunk:
+        return ""
+    if isinstance(chunk, bytes):
+        return chunk.decode("utf-8", errors="replace")
+    return str(chunk)
+
+
+def _ssh_base_command(hostname):
+    return [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
+        "-o",
+        "ConnectTimeout=5",
+        f"{SSH_USERNAME}@{hostname}",
+    ]
+
+
+def _ssh_remote_command(hostname, remote_args):
+    command = _ssh_base_command(hostname)
+    command.append(shlex.join(remote_args))
+    return command
+
+
+def _completion_marker_args():
+    args = []
+    for marker in STARTUP_LOG_COMPLETION_MARKERS:
+        args.extend(["--completion-marker", marker])
+    return args

--- a/duckiebot/startup_logs/startup_log_stream.py
+++ b/duckiebot/startup_logs/startup_log_stream.py
@@ -7,7 +7,7 @@ def _parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--startup-started-at", type=int, required=True)
     parser.add_argument("--poll-interval", type=float, required=True)
-    parser.add_argument("--completion-marker", type=str, required=True)
+    parser.add_argument("--completion-marker", type=str, action="append", required=True)
     parser.add_argument("log_files", nargs="+")
     return parser.parse_args()
 
@@ -19,10 +19,11 @@ def _log_was_updated(path, startup_started_at):
         return False
 
 
-def _stream_startup_logs(log_files, startup_started_at, poll_interval, completion_marker):
+def _stream_startup_logs(log_files, startup_started_at, poll_interval, completion_markers):
     offsets = {path: 0 for path in log_files}
     pending_fragments = {path: "" for path in log_files}
     active_log_files = set()
+    completion_markers_set = set(completion_markers)
     stop_stream = False
     while not stop_stream:
         for path in log_files:
@@ -46,7 +47,7 @@ def _stream_startup_logs(log_files, startup_started_at, poll_interval, completio
                     continue
                 message = line.rstrip()
                 print(message, flush=True)
-                if message == completion_marker:
+                if message in completion_markers_set:
                     stop_stream = True
                     break
             if stop_stream:
@@ -57,7 +58,7 @@ def _stream_startup_logs(log_files, startup_started_at, poll_interval, completio
             continue
         message = pending_fragment.rstrip()
         print(message, flush=True)
-        if message == completion_marker:
+        if message in completion_markers_set:
             break
 
 
@@ -67,7 +68,7 @@ def main():
         log_files=args.log_files,
         startup_started_at=args.startup_started_at,
         poll_interval=args.poll_interval,
-        completion_marker=args.completion_marker,
+        completion_markers=args.completion_marker,
     )
 
 

--- a/duckiebot/virtual/start/command.py
+++ b/duckiebot/virtual/start/command.py
@@ -1,13 +1,12 @@
 import os
 import argparse
-import tarfile
 import time
-from io import BytesIO
 
 import docker as dockerpy
 from dockertown import DockerClient
 from dt_shell import DTCommandAbs, DTShell, dtslogger
 
+from ...startup_logs.common import stream_local_virtual_robot_startup_logs
 from disk_image.create.utils import pull_docker_image
 from utils.duckietown_utils import USER_DATA_DIR
 from utils.misc_utils import pretty_yaml
@@ -16,12 +15,6 @@ from utils.docker_utils import get_endpoint_architecture
 DISK_NAME = "root"
 VIRTUAL_FLEET_DIR = os.path.join(USER_DATA_DIR, "virtual_robots")
 VIRTUAL_ROBOT_RUNTIME_IMAGE = "duckietown/dt-virtual-device:{distro}-{arch}"
-parent_directory = os.path.dirname(__file__)
-STARTUP_LOG_STREAM_SCRIPT_HOST_PATH = os.path.join(parent_directory, "startup_log_stream.py")
-STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH = "/tmp/dts-startup-log-stream.py"
-STARTUP_LOG_FILES = ("/data/logs/first_boot_init.log", "/data/logs/this_boot_init.log")
-STARTUP_LOG_POLL_INTERVAL_SECONDS = 0.1
-STARTUP_LOG_COMPLETION_MARKER = "Setting up completed!"
 
 
 class DTCommand(DTCommandAbs):
@@ -146,7 +139,11 @@ class DTCommand(DTCommandAbs):
                        "It should appear on 'dts fleet discover' soon.")
         if not parsed.no_logs:
             dtslogger.info("Streaming startup logs...")
-            _log_startup_output(local_docker, parsed.robot, startup_started_at)
+            stream_local_virtual_robot_startup_logs(
+                parsed.robot,
+                startup_started_at=startup_started_at,
+                local_docker=local_docker,
+            )
 
 
 def _ensure_volumes_exist(local_docker, robot_name, vbot_root_dir, volume_names, dirs):
@@ -224,80 +221,3 @@ def _populate_volume_from_host(local_docker, volume_name, host_dir_path, contain
         remove=True,
         detach=False
     )
-
-
-def _log_startup_output(local_docker, robot_name, startup_started_at):
-    container_name = f"dts-virtual-{robot_name}"
-    while True:
-        try:
-            container = local_docker.containers.get(container_name)
-            break
-        except dockerpy.errors.NotFound:
-            time.sleep(STARTUP_LOG_POLL_INTERVAL_SECONDS)
-            continue
-    try:
-        if not _copy_startup_log_stream_script(container):
-            return
-        startup_started_at_int = int(startup_started_at)
-        startup_started_at_string = str(startup_started_at_int)
-        startup_log_poll_interval_seconds_string = str(STARTUP_LOG_POLL_INTERVAL_SECONDS)
-        result = container.exec_run(
-            [
-                "python3",
-                STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH,
-                "--startup-started-at",
-                startup_started_at_string,
-                "--poll-interval",
-                startup_log_poll_interval_seconds_string,
-                "--completion-marker",
-                STARTUP_LOG_COMPLETION_MARKER,
-                *STARTUP_LOG_FILES,
-            ],
-            stderr=False,
-            stream=True,
-        )
-    except dockerpy.errors.APIError:
-        return
-    output_stream = result.output if hasattr(result, "output") else result[1]
-    if output_stream is None:
-        return
-    pending_fragment = ""
-    for chunk in output_stream:
-        normalized_chunk = _normalize_exec_output_chunk(chunk)
-        if not normalized_chunk:
-            continue
-        pending_fragment = _log_output_lines(normalized_chunk, pending_fragment)
-    if pending_fragment.strip():
-        message = pending_fragment.rstrip()
-        print(message)
-
-
-def _copy_startup_log_stream_script(container):
-    archive = BytesIO()
-    with tarfile.open(fileobj=archive, mode="w") as tar:
-        arcname = os.path.basename(STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH)
-        tar.add(STARTUP_LOG_STREAM_SCRIPT_HOST_PATH, arcname=arcname)
-    archive.seek(0)
-    path = os.path.dirname(STARTUP_LOG_STREAM_SCRIPT_CONTAINER_PATH)
-    return container.put_archive(path=path, data=archive)
-
-
-def _normalize_exec_output_chunk(chunk):
-    if isinstance(chunk, tuple):
-        chunk = b"".join(part for part in chunk if part)
-    if not chunk:
-        return ""
-    if isinstance(chunk, bytes):
-        return chunk.decode("utf-8", errors="replace")
-    return str(chunk)
-
-
-def _log_output_lines(chunk, pending_fragment):
-    lines = f"{pending_fragment}{chunk}".replace("\r", "\n")
-    lines = lines.split("\n")
-    pending_fragment = lines.pop()
-    for line in lines:
-        if line.strip():
-            message = line.rstrip()
-            print(message)
-    return pending_fragment


### PR DESCRIPTION
This pull request adds a new `startup_logs` command for Duckiebot robots, allowing users to stream startup logs from both physical and virtual robots. The implementation is modular, reusing code for local virtual robots and remote robots, and improves flexibility by supporting multiple completion markers for log streaming. It also refactors the virtual robot startup logic to use the new shared streaming functionality, reducing code duplication.

The most important changes are:

**New Feature: Startup Logs Command**
* Added a new `startup_logs` subcommand under `duckiebot` to stream a DT robot's startup logs, with a user-friendly CLI and error handling. (`command_descriptions.yaml`, `duckiebot/startup_logs/command.py`) [[1]](diffhunk://#diff-cd3e97689812c6244c4ab2f156de18e226285222a17fafe73930a4607eff1ea1R161-R162) [[2]](diffhunk://#diff-8f068acc3e04f545f29265a8a4b44ffd06e592d227affe8e3aedcd924c870a09R1-R24)

**Shared Log Streaming Logic**
* Introduced `duckiebot/startup_logs/common.py` with logic to stream startup logs from both local virtual robots (via Docker) and remote robots (via SSH), supporting multiple completion markers and robust output handling.

**Refactoring & Code Reuse**
* Refactored virtual robot startup in `duckiebot/virtual/start/command.py` to use the new shared log streaming function, removing duplicated code for log streaming and script copying. [[1]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L3-R9) [[2]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L19-L24) [[3]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L149-R146) [[4]](diffhunk://#diff-ed26a1368a6d7036532e625b9d0b259c331f8734512c2267138d412225fa7e69L227-L303)

**Improved Log Streaming Script**
* Updated the log streaming script (now at `duckiebot/startup_logs/startup_log_stream.py`) to accept multiple completion markers and improved its logic to stop streaming when any marker is found. [[1]](diffhunk://#diff-9e3e56c475a271f7fb3fdd67e6febc29840f755c810b909a3a48efe4edb6e45bL10-R10) [[2]](diffhunk://#diff-9e3e56c475a271f7fb3fdd67e6febc29840f755c810b909a3a48efe4edb6e45bL22-R26) [[3]](diffhunk://#diff-9e3e56c475a271f7fb3fdd67e6febc29840f755c810b909a3a48efe4edb6e45bL49-R50) [[4]](diffhunk://#diff-9e3e56c475a271f7fb3fdd67e6febc29840f755c810b909a3a48efe4edb6e45bL60-R61) [[5]](diffhunk://#diff-9e3e56c475a271f7fb3fdd67e6febc29840f755c810b909a3a48efe4edb6e45bL70-R71)

**File Organization**
* Moved and renamed the log streaming script from `duckiebot/virtual/start/startup_log_stream.py` to `duckiebot/startup_logs/startup_log_stream.py` for better organization and reuse.

These changes enable robust and unified streaming of startup logs for both physical and virtual Duckiebots, with improved maintainability and user experience.