### PR TITLE
DTSW-8057-dts-duckiebot-update-does-not-work

### DIFF
--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -133,7 +133,7 @@ services:
     container_name: mavlink-proxy
     depends_on:
       dt-px4:
-        condition: service_healthy
+        condition: service_started
         restart: true
     restart: always
     network_mode: host


### PR DESCRIPTION
This pull request makes a minor update to the `duckiedrone.yaml` stack configuration. The health check condition for the `mavlink-proxy` service's dependency on `dt-px4` has been relaxed to require only that the service has started, not that it is healthy.

* Changed the `depends_on` condition for `dt-px4` from `service_healthy` to `service_started` in `duckiedrone.yaml`, making the `mavlink-proxy` service start as soon as `dt-px4` has started, rather than waiting for it to be healthy.