### PR TITLE
DTSW-8066-Move-camera-driver-to-dt-duckiebot-interface

### DIFF
--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -30,6 +30,8 @@ services:
       - /data:/data
       # dtps sockets
       - /data/ramdisk/dtps:/dtps
+      # libcamera/picamera2 device discovery
+      - /run/udev:/run/udev:ro
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 

--- a/stack/stacks/ros2/duckiedrone.yaml
+++ b/stack/stacks/ros2/duckiedrone.yaml
@@ -24,8 +24,6 @@ services:
       ROS_DOMAIN_ID: 42
     volumes:
       - /data/ramdisk/dtps:/dtps
-      - /dev:/dev
-      - /run/udev:/run/udev:ro
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
     depends_on:


### PR DESCRIPTION
This pull request updates the device and udev volume mounts in the `duckiedrone.yaml` files for both the `duckietown` and `ros2` stacks. The main goal is to ensure that only the necessary device discovery volumes are mounted for each stack, improving security and reducing unnecessary mounts.

**Volume mount changes:**

* Added the `/run/udev:/run/udev:ro` volume to the `duckietown/duckiedrone.yaml` service to support libcamera/picamera2 device discovery.
* Removed the `/dev:/dev` and `/run/udev:/run/udev:ro` volumes from the `ros2/duckiedrone.yaml` service to limit device access and unnecessary mounts.