### PR TITLE
DTSW-8087-Implement-shared-memory-option-for-camera-driver

### DIFF
--- a/stack/stacks/duckietown/duckiebot.yaml
+++ b/stack/stacks/duckietown/duckiebot.yaml
@@ -25,9 +25,14 @@ services:
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-camera
+      DT_CAMERA_SHM_OUT_PATH: ${DT_CAMERA_SHM_OUT_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
       DTPS_DATA_AVAILABILITY_TIMEOUT: 0.1
     volumes:
       - /data:/data
+      - camera-shm:/dtps-shm
       # dtps sockets
       - /data/ramdisk/dtps:/dtps
       # avahi socket
@@ -281,3 +286,5 @@ services:
 
 volumes:
   compose-data:
+  camera-shm:
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}

--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -25,9 +25,14 @@ services:
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-camera
+      DT_CAMERA_SHM_OUT_PATH: ${DT_CAMERA_SHM_OUT_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
       DTPS_DATA_AVAILABILITY_TIMEOUT: 0.1
     volumes:
       - /data:/data
+      - camera-shm:/dtps-shm
       # dtps sockets
       - /data/ramdisk/dtps:/dtps
       # libcamera/picamera2 device discovery
@@ -263,3 +268,5 @@ services:
 
 volumes:
   compose-data:
+  camera-shm:
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}

--- a/stack/stacks/ros1/duckiebot.yaml
+++ b/stack/stacks/ros1/duckiebot.yaml
@@ -9,7 +9,13 @@ services:
     environment:
       DT_LAUNCHER: default
       DT_SUPERUSER: 1
+      DT_CAMERA_SHM_IN_PATH: ${DT_CAMERA_SHM_IN_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
     volumes:
+      - /data/ramdisk:/data/ramdisk
+      - camera-shm:/dtps-shm
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
@@ -40,3 +46,8 @@ services:
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+
+volumes:
+  camera-shm:
+    external: true
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}

--- a/stack/stacks/ros1/duckiedrone.yaml
+++ b/stack/stacks/ros1/duckiedrone.yaml
@@ -10,7 +10,12 @@ services:
     environment:
       DT_LAUNCHER: default
       DT_SUPERUSER: 1
+      DT_CAMERA_SHM_IN_PATH: ${DT_CAMERA_SHM_IN_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
     volumes:
+      - camera-shm:/dtps-shm
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
@@ -40,3 +45,8 @@ services:
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
       - /data:/data
+
+volumes:
+  camera-shm:
+    external: true
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}

--- a/stack/stacks/ros2/duckiebot.yaml
+++ b/stack/stacks/ros2/duckiebot.yaml
@@ -21,8 +21,14 @@ services:
     environment:
       DT_LAUNCHER: sensor-camera
       DT_SUPERUSER: 1
+      DT_CAMERA_SHM_IN_PATH: ${DT_CAMERA_SHM_IN_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
       ROS_DOMAIN_ID: 42
     volumes:
+      - /data/ramdisk:/data/ramdisk
+      - camera-shm:/dtps-shm
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
@@ -214,3 +220,8 @@ services:
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
     depends_on:
       - zenoh-router
+
+volumes:
+  camera-shm:
+    external: true
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}

--- a/stack/stacks/ros2/duckiedrone.yaml
+++ b/stack/stacks/ros2/duckiedrone.yaml
@@ -21,8 +21,14 @@ services:
     environment:
       DT_LAUNCHER: sensor-camera
       DT_SUPERUSER: 1
+      DT_CAMERA_SHM_IN_PATH: ${DT_CAMERA_SHM_IN_PATH:-/dtps-shm/front_center}
+      DT_CAMERA_SHM_ONLY_JPEG: ${DT_CAMERA_SHM_ONLY_JPEG:-0}
+      DT_CAMERA_SHM_ONLY_INFO: ${DT_CAMERA_SHM_ONLY_INFO:-0}
+      DT_CAMERA_SHM_ONLY_PARAMETERS: ${DT_CAMERA_SHM_ONLY_PARAMETERS:-0}
       ROS_DOMAIN_ID: 42
     volumes:
+      - /data/ramdisk:/data/ramdisk
+      - camera-shm:/dtps-shm
       - /data/ramdisk/dtps:/dtps
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
@@ -177,5 +183,8 @@ services:
       # avahi socket
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
-  # Functionalities nodes
-  
+volumes:
+  camera-shm:
+    external: true
+    name: ${DT_CAMERA_SHM_VOLUME:-duckietown-camera-shm}
+


### PR DESCRIPTION
This pull request introduces shared memory (SHM) volume support for camera data across all Duckietown and ROS stack configurations. The main focus is on enabling camera data sharing between containers using a configurable Docker volume and environment variables, with options to control the type of data written or read via SHM. These changes improve modularity, flexibility, and integration of camera data pipelines in both Duckiebot and Duckiedrone setups.

**Shared Memory Volume Integration for Camera Data**

* Added a `camera-shm` Docker volume to all relevant stack YAML files, mounting it at `/dtps-shm` for sharing camera data between containers. The volume name can be customized via the `DT_CAMERA_SHM_VOLUME` environment variable. [[1]](diffhunk://#diff-c5d8ea4d9ed37d76e388b145dd94c77e54efc64e50e9115d117992bd90f1dd7aR28-R35) [[2]](diffhunk://#diff-48d035511b89854c353dc4f23437bad8fe942e8f022c6e287fd15c92e0923c99R28-R35) [[3]](diffhunk://#diff-05bcb9ca82b4b4d41d98a5a75310d477b77d9aec67f36abdb4f74fd6776e6469R12-R18) [[4]](diffhunk://#diff-1b109d6f085ccfa8c3a48438fe2a9aea6521964c6517c13c5786c4b5cda6389fR13-R18) [[5]](diffhunk://#diff-aebcc024387d0c9506e69a5835afb70eb17f94d2f62ccde887186b69454d22c8R24-R31) [[6]](diffhunk://#diff-df4500c8f111b0993b4a054cfabc80c74a6863c37fa8505f2253257e4ca60493R24-R31)

* Exposed new environment variables for camera SHM configuration:
  - `DT_CAMERA_SHM_OUT_PATH`/`DT_CAMERA_SHM_IN_PATH`: Path for SHM data output/input (default `/dtps-shm/front_center`)
  - `DT_CAMERA_SHM_ONLY_JPEG`, `DT_CAMERA_SHM_ONLY_INFO`, `DT_CAMERA_SHM_ONLY_PARAMETERS`: Flags to control which camera data types are sent/received (all default to `0`) [[1]](diffhunk://#diff-c5d8ea4d9ed37d76e388b145dd94c77e54efc64e50e9115d117992bd90f1dd7aR28-R35) [[2]](diffhunk://#diff-48d035511b89854c353dc4f23437bad8fe942e8f022c6e287fd15c92e0923c99R28-R35) [[3]](diffhunk://#diff-05bcb9ca82b4b4d41d98a5a75310d477b77d9aec67f36abdb4f74fd6776e6469R12-R18) [[4]](diffhunk://#diff-1b109d6f085ccfa8c3a48438fe2a9aea6521964c6517c13c5786c4b5cda6389fR13-R18) [[5]](diffhunk://#diff-aebcc024387d0c9506e69a5835afb70eb17f94d2f62ccde887186b69454d22c8R24-R31) [[6]](diffhunk://#diff-df4500c8f111b0993b4a054cfabc80c74a6863c37fa8505f2253257e4ca60493R24-R31)

**Volume Declaration and Configuration**

* Declared the `camera-shm` volume as external in all ROS1 and ROS2 stack files to allow sharing between services, while keeping it internal in Duckietown stacks for local use. [[1]](diffhunk://#diff-05bcb9ca82b4b4d41d98a5a75310d477b77d9aec67f36abdb4f74fd6776e6469R49-R53) [[2]](diffhunk://#diff-1b109d6f085ccfa8c3a48438fe2a9aea6521964c6517c13c5786c4b5cda6389fR48-R52) [[3]](diffhunk://#diff-aebcc024387d0c9506e69a5835afb70eb17f94d2f62ccde887186b69454d22c8R223-R227) [[4]](diffhunk://#diff-df4500c8f111b0993b4a054cfabc80c74a6863c37fa8505f2253257e4ca60493L180-R189) [[5]](diffhunk://#diff-c5d8ea4d9ed37d76e388b145dd94c77e54efc64e50e9115d117992bd90f1dd7aR289-R290) [[6]](diffhunk://#diff-48d035511b89854c353dc4f23437bad8fe942e8f022c6e287fd15c92e0923c99R271-R272)

**Additional Volume Mounts**

* Added `/data/ramdisk` mount to some ROS stack files to ensure temporary data is accessible where needed. [[1]](diffhunk://#diff-05bcb9ca82b4b4d41d98a5a75310d477b77d9aec67f36abdb4f74fd6776e6469R12-R18) [[2]](diffhunk://#diff-aebcc024387d0c9506e69a5835afb70eb17f94d2f62ccde887186b69454d22c8R24-R31) [[3]](diffhunk://#diff-df4500c8f111b0993b4a054cfabc80c74a6863c37fa8505f2253257e4ca60493R24-R31)

These changes collectively standardize and enhance camera data sharing between containers in the Duckietown ecosystem, making integration with vision pipelines more robust and configurable.