### PR TITLE
DTSW-7992-Set-CPU-cap-on-ToF-Sensors

### DIFF
--- a/stack/stacks/duckietown/duckiedrone.yaml
+++ b/stack/stacks/duckietown/duckiedrone.yaml
@@ -41,6 +41,7 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
+    cpus: 0.25
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-tof-bottom
@@ -58,6 +59,7 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
+    cpus: 0.25
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-tof-front
@@ -75,6 +77,7 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
+    cpus: 0.25
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-tof-left
@@ -92,6 +95,7 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
+    cpus: 0.25
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-tof-right
@@ -109,6 +113,7 @@ services:
     restart: unless-stopped
     network_mode: host
     privileged: true
+    cpus: 0.25
     environment:
       DT_SUPERUSER: 1
       DT_LAUNCHER: sensor-tof-top


### PR DESCRIPTION
This PR adds a CPU cap on ToF Sensor Driver Containers of around  `25 %` of 1 CPU core.
Total available cores on RPi 4: 4 Cores
This essentially caps the usage to a max of 1.25 cores / 4 cores (when all 5 Sensors are using max CPU).

CPU usage of `~10%` of 1 CPU core is observed under normal circumstances.