### PR TITLE
DTSW-8090-Add-altitude-package-to-dt-ros2-core

### DIFF
--- a/stack/stacks/ros2-core/duckiedrone.yaml
+++ b/stack/stacks/ros2-core/duckiedrone.yaml
@@ -1,0 +1,14 @@
+services:
+
+  altitude:
+    image: ${REGISTRY}/duckietown/dt-ros2-core:ente-${ARCH}
+    container_name: altitude
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      DT_LAUNCHER: duckiedrone-altitude-node
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data:/data
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket


### PR DESCRIPTION
This pull request introduces a new service definition to the `duckiedrone.yaml` stack configuration. The main change is the addition of the `altitude` service, which sets up the environment and volumes needed for the altitude node in the Duckiedrone ROS2 core stack.

**New service added:**

* Added an `altitude` service to the `services` section, specifying the container image, environment variables (`DT_LAUNCHER`, `ROS_DOMAIN_ID`), and required volume mounts for data persistence and Avahi socket communication.