### PR TITLE
DTSW-8092-Add-duckiedrone_computer_vision-package-to-dt-ros2-core

### DIFF
--- a/stack/stacks/ros2-core/duckiedrone.yaml
+++ b/stack/stacks/ros2-core/duckiedrone.yaml
@@ -1,0 +1,14 @@
+services:
+
+  visual-odometry:
+    image: ${REGISTRY}/duckietown/dt-ros2-core:ente-${ARCH}
+    container_name: visual-odometry
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      DT_LAUNCHER: duckiedrone-visual-odometry
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data:/data
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket


### PR DESCRIPTION
This pull request adds a new service definition to the `duckiedrone.yaml` stack file, introducing the `visual-odometry` service for the Duckiedrone platform.

New service added:

* Added a `visual-odometry` service configured to run with the `dt-ros2-core:ente-${ARCH}` image, using host networking, custom environment variables, and mounted volumes for data and Avahi socket access.