### PR TITLE
DTSW-8096-Add-pid_controller-package-to-dt-ros2-core

### DIFF
--- a/stack/stacks/ros2-core/duckiedrone.yaml
+++ b/stack/stacks/ros2-core/duckiedrone.yaml
@@ -1,0 +1,14 @@
+services:
+
+  pid-controller:
+    image: ${REGISTRY}/duckietown/dt-ros2-core:ente-${ARCH}
+    container_name: pid-controller
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      DT_LAUNCHER: duckiedrone-pid-controller-node
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data:/data
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket


### PR DESCRIPTION
This pull request adds a new service definition to the `duckiedrone.yaml` stack file. The new service, `pid-controller`, is configured to run the `duckiedrone-pid-controller-node` using the `dt-ros2-core` Docker image, with appropriate environment variables, network mode, and volume mounts.

**New service addition:**

* Added a `pid-controller` service to the `stack/stacks/ros2-core/duckiedrone.yaml` file, specifying image, container name, restart policy, network mode, environment variables, and required volume mounts.