### PR TITLE
DTSW-8099-Add-state_estimator-package-to-dt-ros2-core

### DIFF
--- a/stack/stacks/ros2-core/duckiedrone.yaml
+++ b/stack/stacks/ros2-core/duckiedrone.yaml
@@ -1,0 +1,14 @@
+services:
+
+  state-estimator:
+    image: ${REGISTRY}/duckietown/dt-ros2-core:ente-${ARCH}
+    container_name: state-estimator
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      DT_LAUNCHER: duckiedrone-state-estimation-node
+      ROS_DOMAIN_ID: 42
+    volumes:
+      - /data:/data
+      # avahi socket
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket


### PR DESCRIPTION
This pull request adds a new `state-estimator` service to the `duckiedrone.yaml` stack configuration. The service is configured to run the `duckiedrone-state-estimation-node` using the `dt-ros2-core` Docker image.

**New service addition:**

* Added a `state-estimator` service to `stack/stacks/ros2-core/duckiedrone.yaml` with appropriate environment variables, volume mounts, and network settings for state estimation functionality.