### PR TITLE
DTSW-8129-dts-setup-mkcert-does-not-work

### DIFF
--- a/setup/mkcert/command.py
+++ b/setup/mkcert/command.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import tempfile
 import os
 import platform
 import stat
@@ -38,17 +39,32 @@ class DTCommand(DTCommandAbs):
         parsed = parser.parse_args(args=args)
         # define location for SSL certificate and key
         root: str = expanduser(DTShellConstants.ROOT)
+        default_ca_dir: str = join(root, "secrets", "mkcert", "ca")
+        os.makedirs(default_ca_dir, exist_ok=True)
         # check if CAROOT is already set and use it
         ca_variable_name = "CAROOT"
         using_external_caroot = False
         if ca_variable_name in os.environ and os.environ[ca_variable_name]:
-            ca_dir: str = os.environ.get(ca_variable_name)
-            using_external_caroot = True
-            dtslogger.info(f"An existing local Certificate Authority is already installed in {ca_dir}.")
+            external_ca_dir: str = os.environ.get(ca_variable_name)
+            external_ca_cert: str = join(external_ca_dir, "rootCA.pem")
+            external_ca_key: str = join(external_ca_dir, "rootCA-key.pem")
+            external_ca_exists: bool = exists(external_ca_cert) and exists(external_ca_key)
+            external_ca_writable: bool = os.access(external_ca_dir, os.W_OK)
+            if external_ca_exists or external_ca_writable:
+                ca_dir = external_ca_dir
+                using_external_caroot = True
+                if external_ca_exists:
+                    dtslogger.info(f"An existing local Certificate Authority is already installed in {ca_dir}.")
+                else:
+                    dtslogger.info(f"Using writable external Certificate Authority directory {ca_dir}.")
+            else:
+                ca_dir = default_ca_dir
+                dtslogger.warning(
+                    f"Ignoring {ca_variable_name}={external_ca_dir}: the directory does not contain a complete "
+                    f"mkcert CA and is not writable. Falling back to {ca_dir}."
+                )
         else:
-            # - make sure the directory exists
-            ca_dir: str = join(root, "secrets", "mkcert", "ca")
-            os.makedirs(ca_dir, exist_ok=True)
+            ca_dir = default_ca_dir
 
         ssl_dir: str = join(root, "secrets", "mkcert", "ssl")
         cmd_env = {ca_variable_name: ca_dir}
@@ -144,9 +160,17 @@ class DTCommand(DTCommandAbs):
         ssl_cert: str = join(ssl_dir, f"{LOCAL_DOMAIN}.pem")
         ssl_key: str = join(ssl_dir, f"{LOCAL_DOMAIN}-key.pem")
         ssl_exists: bool = exists(ssl_cert) and exists(ssl_key)
+        ssl_valid_for_ca: bool = False
+        if ssl_exists:
+            ssl_valid_for_ca, _ = DTCommand.certificate_valid_for_ca(ssl_cert, ca_cert)
 
         # - make domain certificate
-        if not ssl_exists:
+        if not ssl_exists or not ssl_valid_for_ca:
+            if ssl_exists:
+                dtslogger.warning(
+                    f"Existing domain certificate found in [{ssl_dir}] but it is not signed by the current "
+                    f"Certificate Authority [{ca_cert}]. Regenerating it."
+                )
             dtslogger.info(f"Creating local certificate for the domain '{LOCAL_DOMAIN}' and {LOCAL_IP} ...")
             cmd: List[str] = DTCommand._mkcert_command(
                 "-cert-file", ssl_cert, "-key-file", ssl_key, LOCAL_DOMAIN, LOCAL_IP
@@ -172,28 +196,60 @@ class DTCommand(DTCommandAbs):
     def verify_certificate_validity(domain_certificate_path: str, ca_cert_path: str):
         """Verify that the domain certificate is valid against the local Certificate Authority."""
         dtslogger.info("Verifying the domain certificate...")
-        cmd_verify: List[str] = [
-            "openssl",
-            "verify",
-            "-CAfile",
-            ca_cert_path,
+        is_valid, out_verify = DTCommand.certificate_valid_for_ca(
             domain_certificate_path,
-        ]
-        dtslogger.debug(f"Running command:\n\t$ {' '.join(str(x) for x in cmd_verify)}\n")
+            ca_cert_path,
+            log_errors=True,
+        )
+        dtslogger.info(f"Certificate verification result: {out_verify.strip()}")
+        if not is_valid:
+            raise Exception("The domain certificate is not valid.")
+        dtslogger.info(f"Domain certificate is valid against CA at {ca_cert_path}!")
+        dtslogger.info("If you are using a dev container, ensure the host system also trusts this root CA.")
+
+    @staticmethod
+    def certificate_valid_for_ca(
+        domain_certificate_path: str,
+        ca_cert_path: str,
+        log_errors: bool = False,
+    ):
+        leaf_certificate_path = None
         try:
+            with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as fout:
+                leaf_certificate_path = fout.name
+            cmd_extract: List[str] = [
+                "openssl",
+                "x509",
+                "-in",
+                domain_certificate_path,
+                "-out",
+                leaf_certificate_path,
+            ]
+            dtslogger.debug(f"Running command:\n\t$ {' '.join(str(x) for x in cmd_extract)}\n")
+            subprocess.check_output(cmd_extract, stderr=STDOUT)
+            cmd_verify: List[str] = [
+                "openssl",
+                "verify",
+                "-no-CAfile",
+                "-no-CApath",
+                "-no-CAstore",
+                "-CAfile",
+                ca_cert_path,
+                leaf_certificate_path,
+            ]
+            dtslogger.debug(f"Running command:\n\t$ {' '.join(str(x) for x in cmd_verify)}\n")
             out_verify = subprocess.check_output(cmd_verify, stderr=STDOUT).decode("utf-8")
         except subprocess.CalledProcessError as e:
-            dtslogger.error(f"Command {' '.join(cmd_verify)} failed with exit code {e.returncode}:\n{e.output.decode('utf-8')}")
-            raise
-        dtslogger.info(f"Certificate verification result: {out_verify.strip()}")
-        if "OK" not in out_verify:
-            raise Exception("The domain certificate is not valid.")
-        
-        dtslogger.info(f"Domain certificate is valid against CA at {ca_cert_path}!")
-        dtslogger.info(
-            "If using a devcontainer, ensure the root CA is also installed in the host "
-            "system's trust store by running 'mkcert -install' on your host machine."
-        )
+            out_verify = e.output.decode("utf-8")
+            if log_errors:
+                dtslogger.error(
+                    f"Command {' '.join(cmd_verify)} failed with exit code {e.returncode}:\n{out_verify}"
+                )
+            return False, out_verify
+        finally:
+            if leaf_certificate_path and exists(leaf_certificate_path):
+                os.remove(leaf_certificate_path)
+        return "OK" in out_verify, out_verify
 
     @staticmethod
     def _get_mkcert_bin_url() -> str:


### PR DESCRIPTION
This pull request improves the robustness and correctness of SSL certificate handling in the `setup/mkcert/command.py` script. The main focus is on better handling of the CA directory, ensuring that domain certificates are properly validated against the current CA, and making certificate verification more reliable and informative.

**Certificate Authority (CA) Directory Handling:**
- Improved logic for selecting the CA directory: the script now checks if the `CAROOT` environment variable points to a valid and writable CA directory before using it, otherwise falls back to a default location. Warnings are logged if the external CA directory is incomplete or not writable.

**Certificate Validation and Regeneration:**
- The script now checks if an existing domain certificate is actually signed by the current CA. If not, it logs a warning and regenerates the certificate to ensure trust.

**Certificate Verification Improvements:**
- Refactored certificate verification into a new static method `certificate_valid_for_ca`, which extracts the leaf certificate, uses stricter OpenSSL verification options, and cleans up temporary files. The method returns both a boolean validity and the verification output for better diagnostics.
- The verification process now logs the result and provides clearer error messages if the certificate is invalid.

**Other changes:**
- Added missing `import tempfile` to support temporary file handling during certificate verification.