### PR TITLE
DTSW-8133-Improve-dts-code-editor-browser-handling

### DIFF
--- a/vscode/run/command.py
+++ b/vscode/run/command.py
@@ -26,7 +26,7 @@ except ImportError:
 from dockertown import DockerClient
 from utils.buildx_utils import DOCKER_INFO
 from utils.docker_utils import DEFAULT_REGISTRY, get_endpoint_architecture, sanitize_docker_baseurl
-from utils.misc_utils import human_size, sanitize_hostname, SimpleWindowBrowser
+from utils.misc_utils import human_size, open_browser_url, sanitize_hostname
 
 VSCODE_PORT = 8088
 CONTAINER_SECRETS_DIR = "/run/secrets"
@@ -306,8 +306,7 @@ class DTCommand(DTCommandAbs):
 
         # open web browser tab, give the web browser a second to get up
         time.sleep(1)
-        browser = SimpleWindowBrowser()
-        browser.open(url)
+        open_browser_url(url)
 
         # attach
         if parsed.detach:


### PR DESCRIPTION
This pull request updates how the code opens a web browser to display a URL after starting a container in `vscode/run/command.py`. The main change is replacing the use of the `SimpleWindowBrowser` class with a new function, `open_browser_url`, for opening URLs.

**Refactoring of browser opening logic:**

* Replaced the import of `SimpleWindowBrowser` with `open_browser_url` from `utils.misc_utils` to simplify and standardize how URLs are opened in the browser.
* Updated the `_stop_container` function to use `open_browser_url(url)` instead of creating a `SimpleWindowBrowser` instance, reducing unnecessary object creation and improving clarity.