### PR TITLE
DTSW-8139-Add-on-top-option-for-dts-matrix-run

### DIFF
--- a/matrix/run/command.py
+++ b/matrix/run/command.py
@@ -494,6 +494,8 @@ def configure_renderer_launch(
         app_config += ["--tutorial"]
     if parsed.profiler:
         app_config += ["--profiler"]
+    if parsed.on_top:
+        app_config += ["--on-top"]
     app_config += ["--token", shell.profile.secrets.dt_token]
     billboards_database = DTShellDatabase.open(DB_BILLBOARDS)
     billboard_names = shell.get_billboard_names(billboards_database)

--- a/matrix/run/configuration.py
+++ b/matrix/run/configuration.py
@@ -123,6 +123,12 @@ class DTCommandConfiguration(DTCommandConfigurationAbs):
             help="(Advanced) Force the use of the OpenGL rendering API",
         )
         parser.add_argument(
+            "--on-top",
+            default=False,
+            action="store_true",
+            help="Always stay on top of other windows",
+        )
+        parser.add_argument(
             "--link",
             dest="links",
             nargs=2,


### PR DESCRIPTION
This pull request adds support for an `--on-top` command-line argument, allowing the application window to always stay on top of other windows. The changes include updating the argument parser and ensuring the new argument is passed to the renderer launch configuration.

**New command-line argument:**

* Added `--on-top` argument to the parser in `matrix/run/configuration.py`, enabling users to specify that the application window should always stay on top.

**Renderer launch configuration:**

* Updated `configure_renderer_launch` in `matrix/run/command.py` to append the `--on-top` flag to the renderer's configuration if specified.